### PR TITLE
Feat marker genes

### DIFF
--- a/bin/checkm
+++ b/bin/checkm
@@ -247,9 +247,10 @@ Example: checkm qa ./output/lineage.ms ./output
   5. list of bin id, marker gene id, gene id
   6. list of marker genes present multiple times in a bin
   7. list of marker genes present multiple times on the same scaffold
-  8. list indicating position of each marker gene within a bin''',
+  8. list indicating position of each marker gene within a bin
+  10. FASTA of marker genes identified in each bin''',
   # 9. scaffold statistics: scaffold id, bin id, length, GC, ..., marker gene(s)''',
-                                default=1, choices=[1, 2, 3, 4, 5, 6, 7, 8])
+                                default=1, choices=[1, 2, 3, 4, 5, 6, 7, 8, 10])
     qa_parser.add_argument('--exclude_markers', default=None, help="file specifying marker to exclude from marker sets")
     qa_parser.add_argument('--individual_markers', dest='bIndividualMarkers', action="store_true", default=False, help="treat marker as independent (i.e., ignore co-located set structure)")
     qa_parser.add_argument('--skip_adj_correction', dest='bSkipAdjCorrection', action="store_true", default=False, help="do not exclude adjacent marker genes when estimating contamination")

--- a/checkm/main.py
+++ b/checkm/main.py
@@ -393,7 +393,7 @@ class OptionsParser():
                           )
 
         self.logger.info('')
-        RP.printSummary(options.out_format, aai, binIdToBinMarkerSets, options.bIndividualMarkers, options.coverage_file, options.bTabTable, options.file)
+        RP.printSummary(options.out_format, aai, binIdToBinMarkerSets, options.bIndividualMarkers, options.coverage_file, options.bTabTable, options.file, anaFolder=options.analyze_folder)
         RP.cacheResults(options.analyze_folder, binIdToBinMarkerSets, options.bIndividualMarkers)
 
         if options.file != '':

--- a/checkm/util/seqUtils.py
+++ b/checkm/util/seqUtils.py
@@ -24,7 +24,7 @@ import gzip
 import logging
 
 
-def readFasta(fastaFile):
+def readFasta(fastaFile, trimHeader=True):
     '''Read sequences from FASTA file.'''
     try:
         if fastaFile.endswith('.gz'):
@@ -39,7 +39,10 @@ def readFasta(fastaFile):
                 continue
 
             if line[0] == '>':
-                seqId = line[1:].split(None, 1)[0]
+                if trimHeader:
+                    seqId = line[1:].split(None, 1)[0]
+                else:
+                    seqId = line[1:].rstrip()
                 seqs[seqId] = []
             else:
                 seqs[seqId].append(line[0:-1])


### PR DESCRIPTION
This is an addition that my lab wanted because we wanted to be able to BLAST genes from our bins that were identified as marker genes. 

It looks similar to what I think issue #22 is requesting. With that in mind, I thought I'd upload my code. Feel free pull it into the main branch if this is what you had in mind. It would be possible to sort the genes by contig and position on contig to have an ordered FASTA of marker genes. This isn't currently done for speed reasons but it could be a good complement to a graphic of the dispersion of marker genes across the contigs. My lab also has interest in knowing how evenly dispersed the markers are over the genome bin (to ensure we haven't just happened to assemble a region that is dense in markers which makes it look more complete than it actually is). So, I may work on making a dispersion graphic at some time in the future.

Commit 8ee5f90 message describes the addition in more detail.