### PR TITLE
Send exit code 1 on bin_qa_plot error/failure

### DIFF
--- a/checkm/main.py
+++ b/checkm/main.py
@@ -864,6 +864,8 @@ class OptionsParser():
             self.logger.info('  Plot written to: ' + outputFile)
 
         self.timeKeeper.printTimeStamp()
+        if not bMakePlot:
+            sys.exit(1)
 
     def unbinned(self, options):
         """Unbinned Command"""


### PR DESCRIPTION
When bin_qa_plot fails due to image size, it prints an error message but exits with status 0. It should exit 1 so it can be caught by any parent programs.