### PR TITLE
Exception robustness: mask less exceptions, for (hopefully) better debugging

### DIFF
--- a/checkm/binStatistics.py
+++ b/checkm/binStatistics.py
@@ -96,6 +96,8 @@ class BinStatistics():
 
             writeProc.terminate()
 
+            raise
+
     def __processBin(self, outDir, queueIn, queueOut):
         """Thread safe bin processing."""
         while True:

--- a/checkm/common.py
+++ b/checkm/common.py
@@ -120,7 +120,7 @@ def reassignStdOut(outFile):
         try:
             # redirect stdout to a file
             sys.stdout = open(outFile, 'w')
-        except:
+        except IOError:
             logger = logging.getLogger()
             logger.error("   [Error] Error diverting stdout to file: " + outFile)
             sys.exit(1)
@@ -135,7 +135,7 @@ def restoreStdOut(outFile, oldStdOut):
             # redirect stdout to a file
             sys.stdout.close()
             sys.stdout = oldStdOut
-        except:
+        except IOError:
             logger = logging.getLogger()
             logger.error("   [Error] Error restoring stdout ", outFile)
             sys.exit(1)

--- a/checkm/common.py
+++ b/checkm/common.py
@@ -21,6 +21,7 @@
 
 import os
 import errno
+import subprocess
 import sys
 import ast
 import logging
@@ -138,3 +139,16 @@ def restoreStdOut(outFile, oldStdOut):
             logger = logging.getLogger()
             logger.error("   [Error] Error restoring stdout ", outFile)
             sys.exit(1)
+
+def checkForTool(toolExecutableName):
+    """Check to see if a command line tool is on the current path."""
+    try:
+        subprocess.call([toolExecutableName, '-h'], stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)
+    except OSError as ose:
+        logger = logging.getLogger()
+        if ose.errno == 2 and ose.message == "No such file or directory":
+            logger.error("  [Error] Make sure %s executable is on your system path." % toolExecutableName)
+            sys.exit(1)
+        else:
+            logger.error("  [Error] unexpected exception while checking for %s executable." % toolExecutableName)
+            raise

--- a/checkm/coverage.py
+++ b/checkm/coverage.py
@@ -177,6 +177,8 @@ class Coverage():
 
             writeProc.terminate()
 
+            raise
+
         return coverageInfo
 
     def __workerThread(self, bamFile, bAllReads, minAlignPer, maxEditDistPer, minQC, queueIn, queueOut):

--- a/checkm/coverageWindows.py
+++ b/checkm/coverageWindows.py
@@ -163,6 +163,8 @@ class CoverageWindows():
 
             writeProc.terminate()
 
+            raise
+
         return coverageInfo
 
     def __workerThread(self, bamFile, bAllReads, minAlignPer, maxEditDistPer, windowSize, queueIn, queueOut):

--- a/checkm/genomicSignatures.py
+++ b/checkm/genomicSignatures.py
@@ -186,6 +186,8 @@ class GenomicSignatures(object):
 
             writeProc.terminate()
 
+            raise
+
     def distance(self, sig1, sig2):
         return np.sum(np.abs(sig1 - sig2))
 

--- a/checkm/hmmer.py
+++ b/checkm/hmmer.py
@@ -114,9 +114,13 @@ class HMMERRunner():
         """Check to see if HMMER is on the system path."""
         try:
             subprocess.call(['hmmsearch', '-h'], stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)
-        except:
-            self.logger.error("  [Error] Make sure HMMER executables (e.g., hmmsearch, hmmfetch) are on your system path.")
-            sys.exit(1)
+        except OSError as ose:
+            if ose.errno == 2 && ose.message == "No such file or directory":
+                self.logger.error("  [Error] Make sure HMMER executables (e.g., hmmsearch, hmmfetch) are on your system path.")
+                sys.exit(1)
+            else:
+                self.logger.error("  [Error] unexpected exception while checking for HMMER executables.")
+                raise
 
 
 class HMMERParser():

--- a/checkm/hmmer.py
+++ b/checkm/hmmer.py
@@ -20,9 +20,10 @@
 ###############################################################################
 
 import os
-import sys
 import logging
-import subprocess
+
+from checkm.common import checkForTool
+
 from re import split as re_split
 
 
@@ -112,15 +113,9 @@ class HMMERRunner():
 
     def checkForHMMER(self):
         """Check to see if HMMER is on the system path."""
-        try:
-            subprocess.call(['hmmsearch', '-h'], stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)
-        except OSError as ose:
-            if ose.errno == 2 && ose.message == "No such file or directory":
-                self.logger.error("  [Error] Make sure HMMER executables (e.g., hmmsearch, hmmfetch) are on your system path.")
-                sys.exit(1)
-            else:
-                self.logger.error("  [Error] unexpected exception while checking for HMMER executables.")
-                raise
+
+        checkForTool('hmmsearch')
+        checkForTool('hmmfetch')
 
 
 class HMMERParser():

--- a/checkm/hmmerAligner.py
+++ b/checkm/hmmerAligner.py
@@ -177,6 +177,8 @@ class HmmerAligner:
 
             writeProc.terminate()
 
+            raise
+
     def __createMSA(self, resultsParser, binIdToBinMarkerSets, hmmModelFile, outDir, alignOutputDir, queueIn, queueOut):
         """Create multiple sequence alignment for markers with multiple hits in a bin."""
 
@@ -262,6 +264,8 @@ class HmmerAligner:
                 p.terminate()
 
             writeProc.terminate()
+
+            raise
 
     def __alignMarkerParallel(self, markerSeqs, markerStats, bReportHitStats, alignOutputDir, hmmModelFiles, bKeepUnmaskedAlign, queueIn, queueOut):
         while True:
@@ -489,6 +493,8 @@ class HmmerAligner:
                 p.terminate()
 
             writeProc.terminate()
+
+            raise
 
     def __extractModel(self, hmmModelFile, queueIn, queueOut):
         """Extract HMM."""

--- a/checkm/main.py
+++ b/checkm/main.py
@@ -1210,19 +1210,13 @@ class OptionsParser():
 
     def parseOptions(self, options):
         """Parse user options and call the correct pipeline(s)"""
-        try:
-            if hasattr(options, 'bQuiet') and options.bQuiet:
-                logging.basicConfig(format='', level=logging.ERROR)
-            else:
-                logging.basicConfig(format='', level=logging.INFO)
-        except:
+        if hasattr(options, 'bQuiet') and options.bQuiet:
+            logging.basicConfig(format='', level=logging.ERROR)
+        else:
             logging.basicConfig(format='', level=logging.INFO)
 
-        try:
-            if options.file == "stdout":
-                options.file = ''
-        except:
-            pass
+        if hasattr(options, 'file') and options.file == "stdout":
+            options.file = ''
 
         if(options.subparser_name == "data"):
             self.updateCheckM_DB(options)

--- a/checkm/markerGeneFinder.py
+++ b/checkm/markerGeneFinder.py
@@ -87,6 +87,8 @@ class MarkerGeneFinder():
 
             writeProc.terminate()
 
+            raise
+
         # create a standard dictionary from the managed dictionary
         d = {}
         for binId in binIdToModels.keys():

--- a/checkm/markerSets.py
+++ b/checkm/markerSets.py
@@ -379,6 +379,8 @@ class MarkerSetParser():
 
             writeProc.terminate()
 
+            raise
+
         # create a standard dictionary from the managed dictionary
         d = {}
         for binId in binIdToModels.keys():

--- a/checkm/plot/gcPlots.py
+++ b/checkm/plot/gcPlots.py
@@ -65,10 +65,9 @@ class GcPlots(AbstractPlot):
                 a, c, g, t = baseCount(seq[start:end])
                 try:
                     data.append(float(g + c) / (a + c + g + t))
-                except:
+                except ZeroDivisionError:
                     # it is possible to reach a long stretch of
                     # N's that causes a division by zero error
-
                     pass
 
                 start = end

--- a/checkm/pplacer.py
+++ b/checkm/pplacer.py
@@ -20,16 +20,15 @@
 ###############################################################################
 
 import os
-import sys
 import stat
 import shutil
-import subprocess
 import logging
 from collections import defaultdict
 
 from checkm.defaultValues import DefaultValues
 
-from checkm.common import checkDirExists
+from checkm.common import checkDirExists, checkForTool
+
 from checkm.util.seqUtils import readFasta, writeFasta
 
 
@@ -128,21 +127,9 @@ class PplacerRunner():
     def __checkForPplacer(self):
         """Check to see if pplacer is on the system before we try to run it."""
 
-        # Assume that a successful pplacer -h returns 0 and anything
-        # else returns something non-zero
-        try:
-            subprocess.call(['pplacer', '-h'], stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)
-        except:
-            self.logger.error("  [Error] Make sure pplacer is on your system path.")
-            sys.exit(1)
+        checkForTool('pplacer')
 
     def __checkForGuppy(self):
         """Check to see if guppy is on the system before we try to run it."""
 
-        # Assume that a successful pplacer -h returns 0 and anything
-        # else returns something non-zero
-        try:
-            subprocess.call(['guppy', '-h'], stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)
-        except:
-            self.logger.error("  [Error] Make sure guppy, which is part of the pplacer package, is on your system path.")
-            sys.exit(1)
+       checkForTool('guppy')

--- a/checkm/prodigal.py
+++ b/checkm/prodigal.py
@@ -20,16 +20,14 @@
 ###############################################################################
 
 import os
-import sys
 import stat
-import subprocess
 import logging
 import shutil
 
 import numpy as np
 
 from checkm.defaultValues import DefaultValues
-from checkm.common import checkFileExists
+from checkm.common import checkFileExists, checkForTool
 from checkm.util.seqUtils import readFasta
 
 
@@ -128,13 +126,7 @@ class ProdigalRunner():
     def checkForProdigal(self):
         """Check to see if Prodigal is on the system before we try to run it."""
 
-        # Assume that a successful prodigal -h returns 0 and anything
-        # else returns something non-zero
-        try:
-            subprocess.call(['prodigal', '-h'], stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)
-        except:
-            self.logger.error("  [Error] Make sure prodigal is on your system path.")
-            sys.exit(1)
+        checkForTool('prodigal')
 
 
 class ProdigalFastaParser():

--- a/checkm/resultsParser.py
+++ b/checkm/resultsParser.py
@@ -387,7 +387,7 @@ class ResultsManager():
                             try:
                                 orfNumI = int(orfI[orfI.rfind('_') + 1:])
                                 orfNumJ = int(orfJ[orfJ.rfind('_') + 1:])
-                            except:
+                            except ValueError:
                                 # it appears called genes are not labeled
                                 # according to the prodigal format, so
                                 # it is not possible to perform this correction

--- a/checkm/treeParser.py
+++ b/checkm/treeParser.py
@@ -567,7 +567,7 @@ class TreeParser():
                 d['taxonomy'] = lineSplit[2]
                 try:
                     d['bootstrap'] = float(lineSplit[3])
-                except:
+                except ValueError:
                     d['bootstrap'] = 'NA'
                 d['gc mean'] = float(lineSplit[4])
                 d['gc std'] = float(lineSplit[5])

--- a/checkm/util/img.py
+++ b/checkm/util/img.py
@@ -138,23 +138,23 @@ class IMG(object):
             try:
                 metadata[genomeId]['GC Count'] = int(lineSplit[gcIndex])
                 metadata[genomeId]['GC %'] = float(lineSplit[gcIndex]) / int(lineSplit[genomeSizeIndex])
-            except:
+            except ValueError:
                 metadata[genomeId]['GC Count'] = 'NA'
                 metadata[genomeId]['GC %'] = 'NA'
 
             try:
                 metadata[genomeId]['genome size'] = int(lineSplit[genomeSizeIndex])
-            except:
+            except ValueError:
                 metadata[genomeId]['genome size'] = 'NA'
 
             try:
                 metadata[genomeId]['gene count'] = int(lineSplit[geneCountIndex])
-            except:
+            except ValueError:
                 metadata[genomeId]['gene count'] = 'NA'
 
             try:
                 metadata[genomeId]['coding base count'] = int(lineSplit[codingBaseCountIndex])
-            except:
+            except ValueError:
                 metadata[genomeId]['coding base count'] = 'NA'
 
             metadata[genomeId]['biotic relationships'] = lineSplit[bioticRelationshipsIndex]

--- a/checkm/util/seqUtils.py
+++ b/checkm/util/seqUtils.py
@@ -207,7 +207,8 @@ def readFasta(fastaFile, trimHeader=True):
     except:
         logger = logging.getLogger()
         logger.error("  [Error] Failed to process sequence file: " + fastaFile)
-        sys.exit()
+
+        raise
 
     return seqs
 

--- a/scripts/genomeTreeWorkflow.py
+++ b/scripts/genomeTreeWorkflow.py
@@ -32,6 +32,8 @@ import os
 import sys
 import argparse
 
+from checkm.common import checkForTool
+
 from genometreeworkflow.phylogeneticInferenceGenes import PhylogeneticInferenceGenes
 from genometreeworkflow.makeTrees import MakeTrees
 from genometreeworkflow.paralogTest import ParalogTest
@@ -95,54 +97,24 @@ class GenomeTreeWorkflow(object):
     def __checkForHMMER(self):
         """Check to see if HMMER is on the system path."""
 
-        try:
-            exit_status = os.system('hmmfetch -h > /dev/null')
-        except:
-            print "Unexpected error!", sys.exc_info()[0]
-            raise
+        checkForTool('hmmsearch')
+        checkForTool('hmmfetch')
 
-        if exit_status != 0:
-            print "[Error] hmmfetch is not on the system path"
-            sys.exit()
 
     def __checkForFastTree(self):
         """Check to see if FastTree is on the system path."""
 
-        try:
-            exit_status = os.system('FastTree 2> /dev/null')
-        except:
-            print "Unexpected error!", sys.exc_info()[0]
-            raise
-
-        if exit_status != 0:
-            print "[Error] FastTree is not on the system path"
-            sys.exit()
+       checkForTool('FastTree')
 
     def __checkForSeqMagick(self):
         """Check to see if seqmagick is on the system path."""
 
-        try:
-            exit_status = os.system('seqmagick -h > /dev/null')
-        except:
-            print "Unexpected error!", sys.exc_info()[0]
-            raise
-
-        if exit_status != 0:
-            print "[Error] seqmagick is not on the system path"
-            sys.exit()
+        checkForTool('seqmagick')
 
     def __checkForTax2Tree(self):
         """Check to see if tax2tree is on the system path."""
 
-        try:
-            exit_status = os.system('t2t -h > /dev/null')
-        except:
-            print "Unexpected error!", sys.exc_info()[0]
-            raise
-
-        if exit_status != 0:
-            print "[Error] t2t is not on the system path"
-            sys.exit()
+        checkForTool('t2t')
 
     def run(self, numThreads):
         # identify genes suitable for phylogenetic inference

--- a/scripts/genometreeworkflow/createSmallTree.py
+++ b/scripts/genometreeworkflow/createSmallTree.py
@@ -52,15 +52,19 @@ class CreateSamllTree(object):
     def __checkForFastTree(self):
         """Check to see if FastTree is on the system path."""
 
+        # Assume that a successful FastTree -h returns 0 and anything
+        # else returns something non-zero
         try:
-            exit_status = os.system('FastTree 2> /dev/null')
-        except:
-            print "Unexpected error!", sys.exc_info()[0]
-            raise
+            subprocess.call(['FastTree'], stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)
+        except OSError as ose:
+            if ose.errno == 2 and ose.message == "No such file or directory":
+                self.logger.error("  [Error] Make sure `FastTree` is on your system path.")
+                sys.exit(1)
+            else:
+                self.logger.error("  [Error] unexpected exception while checking for `FastTree`.")
+                raise
 
-        if exit_status != 0:
-            print "[Error] FastTree is not on the system path"
-            sys.exit()
+
 
     def __nearlyIdentical(self, string1, string2, max_diff_perc=0.08):
         max_diff = int(max_diff_perc * len(string1))

--- a/scripts/genometreeworkflow/markerSetBuilder.py
+++ b/scripts/genometreeworkflow/markerSetBuilder.py
@@ -404,7 +404,7 @@ class MarkerSetBuilder(object):
                 d['taxonomy'] = lineSplit[2]
                 try:
                     d['bootstrap'] = float(lineSplit[3])
-                except:
+                except ValueError:
                     d['bootstrap'] = 'NA'                 
                 d['gc mean'] = float(lineSplit[4])
                 d['gc std'] = float(lineSplit[5])

--- a/scripts/genometreeworkflow/rerootTree.py
+++ b/scripts/genometreeworkflow/rerootTree.py
@@ -68,7 +68,7 @@ class RerootTree(object):
                 genomeId = self.__genomeId(t.taxon.label)
                 genomeIds.add(genomeId)
                 domain = self.metadata[genomeId]['taxonomy'][0].lower()
-            except:
+            except KeyError:
                 print '[Error] Missing IMG metadata for: ' + t.taxon.label
                 sys.exit()
 

--- a/scripts/taxonomicTreeWorkflow.py
+++ b/scripts/taxonomicTreeWorkflow.py
@@ -35,6 +35,8 @@ from collections import defaultdict
 import multiprocessing as mp
 import random
 
+from checkm.common import checkForTool
+
 from checkm.lib.img import IMG
 
 from lib.markerSetBuilder import MarkerSetBuilder
@@ -102,28 +104,13 @@ class GenomeTreeWorkflow(object):
     def __checkForHMMER(self):
         """Check to see if HMMER is on the system path."""
 
-        try:
-            exit_status = os.system('hmmfetch -h > /dev/null')
-        except:
-            print "Unexpected error!", sys.exc_info()[0]
-            raise
-
-        if exit_status != 0:
-            print "[Error] hmmfetch is not on the system path"
-            sys.exit()
+        checkForTool('hmmsearch')
+        checkForTool('hmmfetch')
 
     def __checkForFastTree(self):
         """Check to see if FastTree is on the system path."""
 
-        try:
-            exit_status = os.system('FastTree 2> /dev/null')
-        except:
-            print "Unexpected error!", sys.exc_info()[0]
-            raise
-
-        if exit_status != 0:
-            print "[Error] FastTree is not on the system path"
-            sys.exit()
+        checkForTool('FastTree')
 
     def __genesInGenomes(self, genomeIds):
         genesInGenomes = {}


### PR DESCRIPTION
I've been looking at #195 together with @johanneswerner. Unfortunately, our diagnoses were hindered by all the stacktraces being swallowed.
This PR is the result of a small crusade against catch-all `excepts` in the code-base, in the hopes of getting better traces in the future.

This is our first dive into the CheckM code, so we're likely to do dumb things out of ignorance :neutral_face: 
Our apologies in advance, and please help us improve!

We've tried to group different types of fixes into separate commits, for easier reviewing.
If any of our changes are unacceptable for some reason, please do let us know what to change.
Of course, if certain types of changes are not desired, we're happy to leave them out.

While we were at it, we noticed that there were a lot of repeated implementations of "try to call tool, and error out if missing". We've condensed these into one consistent implementation.
The best place we found for this consolidated `def` was `checkm.common`, but will gladly move it elsewhere if we missed something.
