### PR TITLE
Set default location for checkm data

### DIFF
--- a/checkm/checkmData.py
+++ b/checkm/checkmData.py
@@ -116,7 +116,7 @@ class DBManager(mm.ManifestManager):
 
     def runAction(self, action):
         """Main entry point for the updating code"""
-        
+
         if action[0] == "setRoot":
             if len(action) > 1:
                 path = self.setRoot(path=action[1])
@@ -156,11 +156,12 @@ class DBManager(mm.ManifestManager):
         minimal = False
         while not path_set:
             if not path:
-                if(minimal):
-                    path = raw_input("Please specify a location or type 'abort' to stop trying: \n")
-                else:
-                    path = raw_input("Where should CheckM store it's data?\n" \
-                                    "Please specify a location or type 'abort' to stop trying: \n")
+                path = os.path.join(os.path.expanduser("~"), ".checkm")
+                # if(minimal):
+                #     path = raw_input("Please specify a location or type 'abort' to stop trying: \n")
+                # else:
+                #     path = raw_input("Where should CheckM store it's data?\n" \
+                #                     "Please specify a location or type 'abort' to stop trying: \n")
 
             if path.upper() == "ABORT":
                 # user has given up


### PR DESCRIPTION
Hi CheckM folks!  Thanks for making a great tool!  I have a small request: can we make a default place for the database?  Requiring user input makes it tricky to install in a pipeline context (See  https://github.com/edgraham/BinSanity/issues/29, https://github.com/ISU-HPC/bamm-groopm-checkm/issues/1, https://github.com/nf-core/mag/issues/13).  The change I purpose here makes a dot directory in the users home folder -- no privilege issues that I know about, and complies with section 3.8.2 of the File Hierarchy Standard https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s08.html

While the changes in this PR only are for the data dir, having this would also be a nice place for putting the CONFIG_DATA file, as it seems like some users are running into permissions problems when using CheckM inside containers.  

I know you are working on CheckM 2.0, but if this is something you would consider, let me know how I could help make it happen!

Thanks again,

Nick