### PR TITLE
fixes infinite loop

### DIFF
--- a/checkm/markerSets.py
+++ b/checkm/markerSets.py
@@ -112,6 +112,7 @@ class BinMarkerSets():
                 # this could be avoided by just forcing in the selected
                 # marker set.
                 selectedId = selectedMarkerSetMap[selectedId]
+                break
             else:
                 break
 


### PR DESCRIPTION
CheckM gets stuck in an infinite loop in a rare edgecase when `--reduced_tree` is enabled. Sorry, I don't have a fasta file that reproduces the bug.