### PR TITLE
fix stringent matching while searching for genomes

### DIFF
--- a/checkm/main.py
+++ b/checkm/main.py
@@ -84,7 +84,7 @@ class OptionsParser():
         if binFolder is not None:
             all_files = os.listdir(binFolder)
             for f in all_files:
-                if f.endswith(binExtension):
+                if f.endswith("." + binExtension):
                     binFile = os.path.join(binFolder, f)
                     if os.stat(binFile).st_size == 0:
                         self.logger.warning("Skipping bin %s as it has a size of 0 bytes." % f)


### PR DESCRIPTION
Hi, thanks for such a useful tool.

This branch is just to let checkm search genomes in a stringent matching way when listing for genomes by matching a specific binExtension. It is a very minor point, but should be useful when the input bindir is a little bit mess.