### PR TITLE
Allow user to specify path to `DATA_CONFIG` file, for use with Singularity containers

### DIFF
--- a/bin/checkm
+++ b/bin/checkm
@@ -117,8 +117,10 @@ if __name__ == '__main__':
                                         description='Set path to the CheckM database files.',
                                         epilog='Example: checkm data setRoot')
     data_parser.add_argument('action', nargs="+",
-            help='''
-  setRoot <CONFIG_PATH> <DB_PATH>  -> set the checkM DATA_CONFIG FILE to CONFIG_PATH and the checkm data directory to <DB_PATH> (requires permissions)
+            help='''b
+  setRoot <DB_PATH> -> set the the checkm data directory to <DB_PATH> (requires permissions)
+  or 
+  setRoot <DB_PATH> <CONFIG_PATH> -> set the the checkm data directory to <DB_PATH> and the checkM DATA_CONFIG FILE to CONFIG_PATH (requires permissions)
             ''')
 
     # determine placement of each genome bin in the genome tree

--- a/bin/checkm
+++ b/bin/checkm
@@ -118,7 +118,7 @@ if __name__ == '__main__':
                                         epilog='Example: checkm data setRoot')
     data_parser.add_argument('action', nargs="+",
             help='''
-  setRoot <PATH>  -> set the data directory to <PATH> (requires permissions)
+  setRoot <CONFIG_PATH> <DB_PATH>  -> set the checkM DATA_CONFIG FILE to CONFIG_PATH and the checkm data directory to <DB_PATH> (requires permissions)
             ''')
 
     # determine placement of each genome bin in the genome tree

--- a/checkm/checkmData.py
+++ b/checkm/checkmData.py
@@ -125,7 +125,7 @@ class DBManager(mm.ManifestManager):
         
         if action[0] == "setRoot":
             if len(action) > 1:
-                path = self.setRoot(path=action[2])
+                path = self.setRoot(path=action[1])
             else:
                 path = self.setRoot()
 

--- a/checkm/checkmData.py
+++ b/checkm/checkmData.py
@@ -34,9 +34,9 @@ class DBConfig(object):
     stored locally and where to look for remote updates. This class essentially exposes
     the DATA_CONFIG file as an object.
     """
-    def __init__(self):
+    def __init__(self, configFile):
         self.logger = logging.getLogger('timestamp')
-        self.configFile = os.path.abspath(resource_filename('checkm', 'DATA_CONFIG'))
+        self.configFile = configFile
         self.values = self.getConfig()
 
 #-----------------------------------------------------------------------------
@@ -97,10 +97,10 @@ class DBConfig(object):
 class DBManager(mm.ManifestManager):
 
     """Manage all aspects of data location and version control."""
-    def __init__(self, set_path=None):
+    def __init__(self, set_path=None, configFile = os.path.abspath(resource_filename('checkm', 'DATA_CONFIG')):
         mm.ManifestManager.__init__(self, timeout=15)
         self.logger = logging.getLogger('timestamp')
-        self.config = DBConfig()  # load inbuilt configuration
+        self.config = DBConfig(configFile = configFile)  # load inbuilt configuration
         self.type = self.config.values["manifestType"]
         
         if set_path:
@@ -125,7 +125,7 @@ class DBManager(mm.ManifestManager):
         
         if action[0] == "setRoot":
             if len(action) > 1:
-                path = self.setRoot(path=action[1])
+                path = self.setRoot(path=action[2])
             else:
                 path = self.setRoot()
 

--- a/checkm/main.py
+++ b/checkm/main.py
@@ -74,8 +74,11 @@ class OptionsParser():
         self.logger.info('[CheckM - data] Check for database updates. [%s]' % options.action[0])
 
         action = options.action
-        if action and action[0] == 'setRoot' and len(action) > 1:
-            DBM = DBManager(configFile = action[1], set_path=action[2])
+        if action and action[0] == 'setRoot':
+            if len(action) > 2:
+                DBM = DBManager(set_path=action[1], configFile = action[2])
+            elif len(action) > 1:
+                DBM = DBManager(set_path=action[1])
         else:
             self.logger.error('Path to the CheckM reference data must be specified.')
 

--- a/checkm/main.py
+++ b/checkm/main.py
@@ -75,7 +75,7 @@ class OptionsParser():
 
         action = options.action
         if action and action[0] == 'setRoot' and len(action) > 1:
-            DBM = DBManager(set_path=action[1])
+            DBM = DBManager(configFile = action[1], set_path=action[2])
         else:
             self.logger.error('Path to the CheckM reference data must be specified.')
 


### PR DESCRIPTION
Hi @dparks1134 and @ctSkennerton ,
First of all, thanks for creating CheckM, it's a very much needed tool for working with *de novo* assembly binning !

Right now, the way CheckM is set up, the `DATA_CONFIG` file is distributed with the checkm python package, and updated on the same path when running the `checkm data setRoot <PATH_TO_DB_DIR>` command.

This is causing an issue when running checkM with [singularity containers](https://sylabs.io/guides/3.5/user-guide/introduction.html) as they are read only file-system (i.e. the checkm package files can not be overwritten).

For example:

```bash 
$ singularity shell quay.io/biocontainers/checkm-genome:1.1.3--py_1
Singularity> checkm data setRoot ~/tmp/checkm/
[2022-03-01 15:40:09] INFO: CheckM v1.1.3
[2022-03-01 15:40:09] INFO: checkm data setRoot /home/maxime_borry/tmp/checkm/
[2022-03-01 15:40:09] INFO: [CheckM - data] Check for database updates. [setRoot]

Unexpected error: <class 'NameError'>
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/checkm/checkmData.py", line 87, in checkPermissions
    open(self.configFile, 'a')
OSError: [Errno 30] Read-only file system: '/usr/local/lib/python3.7/site-packages/checkm/DATA_CONFIG'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/checkm", line 611, in <module>
    checkmParser.parseOptions(args)
  File "/usr/local/lib/python3.7/site-packages/checkm/main.py", line 834, in parseOptions
    self.updateCheckM_DB(options)
  File "/usr/local/lib/python3.7/site-packages/checkm/main.py", line 78, in updateCheckM_DB
    DBM = DBManager(set_path=action[1])
  File "/usr/local/lib/python3.7/site-packages/checkm/checkmData.py", line 107, in __init__
    self.setRoot(set_path)
  File "/usr/local/lib/python3.7/site-packages/checkm/checkmData.py", line 142, in setRoot
    if not self.config.checkPermissions():
  File "/usr/local/lib/python3.7/site-packages/checkm/checkmData.py", line 88, in checkPermissions
    except (IOError, e):
NameError: name 'e' is not defined
```

What I propose with this pull request is to allow the user to specify the `DATA_CONFIG` path, so that it can be also on a writeable filesystem.

With this modification, the user can use:
- `checkm data setRoot <PATH_TO_DB_DIR>` like before, and use the `DATA_CONFIG` file provided with the checkM package
- `checkm data setRoot <DB_PATH> <CONFIG_PATH>` to also specify the path to a `DATA_CONFIG` file somewhere writeable.

Note: this feature is particularly relevant for the integration of checkm in computation pipelines for HPC, such as in [nf-core/mag](https://github.com/nf-core/mag/issues/13)
