### PR TITLE
Support table as input for checkm bins

### DIFF
--- a/bin/checkm
+++ b/bin/checkm
@@ -132,7 +132,9 @@ if __name__ == '__main__':
                                         description='Place bins in the genome tree.',
                                         epilog='Example: checkm tree ./bins ./output')
     tree_parser.add_argument(
-        'bin_dir', help="directory containing bins (fasta format)")
+        'bin_input', help="directory containing bins (fasta format) or "
+                          "path to file describing genomes/genes - tab "
+                          "separated in 2 or 3 columns [genome ID, genome fna, genome translation file (pep)]")
     tree_parser.add_argument(
         'output_dir', help="directory to write output files")
     tree_parser.add_argument('-r', '--reduced_tree', dest='bReducedTree', action="store_true",
@@ -233,7 +235,9 @@ if __name__ == '__main__':
     analyze_parser.add_argument(
         'marker_file', help="markers for assessing bins (marker set or HMM file)")
     analyze_parser.add_argument(
-        'bin_dir', help="directory containing bins (fasta format)")
+        'bin_input', help="directory containing bins (fasta format) or "
+                          "path to file describing genomes/genes - tab "
+                          "separated in 2 or 3 columns [genome ID, genome fna, genome translation file (pep)]")
     analyze_parser.add_argument(
         'output_dir', help="directory to write output files")
     analyze_parser.add_argument('--ali', dest='bKeepAlignment', action="store_true",
@@ -320,7 +324,9 @@ Example: checkm qa ./output/lineage.ms ./output
                                               description='Runs tree, lineage_set, analyze, qa',
                                               epilog='Example: checkm lineage_wf ./bins ./output')
     lineage_wf_parser.add_argument(
-        'bin_dir', help="directory containing bins (fasta format)")
+        'bin_input', help="directory containing bins (fasta format) or "
+                          "path to file describing genomes/genes - tab "
+                          "separated in 2 or 3 columns [genome ID, genome fna, genome translation file (pep)]")
     lineage_wf_parser.add_argument(
         'output_dir', help="directory to write output files")
     lineage_wf_parser.add_argument('-r', '--reduced_tree', dest='bReducedTree', action="store_true",
@@ -380,7 +386,9 @@ Example: checkm qa ./output/lineage.ms ./output
                                     'life', 'domain', 'phylum', 'class', 'order', 'family', 'genus', 'species'])
     taxonomy_wf_parser.add_argument('taxon', help="taxon of interest")
     taxonomy_wf_parser.add_argument(
-        'bin_dir', help="directory containing bins (fasta format)")
+        'bin_input', help="directory containing bins (fasta format) or "
+                          "path to file describing genomes/genes - tab "
+                          "separated in 2 or 3 columns [genome ID, genome fna, genome translation file (pep)]")
     taxonomy_wf_parser.add_argument(
         'output_dir', help="directory to write output files")
     taxonomy_wf_parser.add_argument('--ali', dest='bKeepAlignment', action="store_true",
@@ -428,7 +436,9 @@ Example: checkm qa ./output/lineage.ms ./output
 
     plot_parser = argparse.ArgumentParser('plot', add_help=False)
     plot_parser.add_argument(
-        'bin_dir', help="directory containing bins to plot (fasta format)")
+        'bin_input', help="directory containing bins (fasta format) or "
+                          "path to file describing genomes/genes - tab "
+                          "separated in 2 or 3 columns [genome ID, genome fna, genome translation file (pep)]")
     plot_parser.add_argument('output_dir', help="directory to hold plots")
     plot_parser.add_argument('--image_type', default='png',
                              choices=['eps', 'pdf', 'png', 'ps', 'svg'], help='desired image type')
@@ -520,7 +530,9 @@ Example: checkm qa ./output/lineage.ms ./output
     plot_dist_parser.add_argument(
         'results_dir', help="directory specified during analyze command")
     plot_dist_parser.add_argument(
-        'bin_dir', help="directory containing bins to plot (fasta format)")
+        'bin_input', help="directory containing bins (fasta format) or "
+                          "path to file describing genomes/genes - tab "
+                          "separated in 2 or 3 columns [genome ID, genome fna, genome translation file (pep)]")
     plot_dist_parser.add_argument('output_dir', help="directory to hold plots")
     plot_dist_parser.add_argument(
         'tetra_profile', help='tetranucleotide profiles for each sequence (see tetra command)')
@@ -617,7 +629,9 @@ Example: checkm qa ./output/lineage.ms ./output
                                             description='Identify unbinned sequences.',
                                             epilog='Example: checkm unbinned ./bins seqs.fna unbinned.fna unbinned_stats.tsv')
     unbinned_parser.add_argument(
-        'bin_dir', help="directory containing bins (fasta format)")
+        'bin_input', help="directory containing bins (fasta format) or "
+                          "path to file describing genomes/genes - tab "
+                          "separated in 2 or 3 columns [genome ID, genome fna, genome translation file (pep)]")
     unbinned_parser.add_argument(
         'seq_file', help="sequences used to generate bins (fasta format)")
     unbinned_parser.add_argument(
@@ -636,9 +650,10 @@ Example: checkm qa ./output/lineage.ms ./output
                                             formatter_class=CustomHelpFormatter,
                                             description='Calculate coverage of sequences.',
                                             epilog='Example: checkm coverage ./bins coverage.tsv example_1.bam example_2.bam')
-
     coverage_parser.add_argument(
-        'bin_dir', help="directory containing bins (fasta format)")
+        'bin_input', help="directory containing bins (fasta format) or "
+                          "path to file describing genomes/genes - tab "
+                          "separated in 2 or 3 columns [genome ID, genome fna, genome translation file (pep)]")
     coverage_parser.add_argument('output_file', help="print results to file")
     coverage_parser.add_argument(
         'bam_files', nargs='+', help="BAM files to parse")
@@ -693,7 +708,9 @@ Example: checkm qa ./output/lineage.ms ./output
     ssu_finder_parser.add_argument(
         'seq_file', help="sequences used to generate bins (fasta format)")
     ssu_finder_parser.add_argument(
-        'bin_dir', help="directory containing bins (fasta format)")
+        'bin_input', help="directory containing bins (fasta format) or "
+                          "path to file describing genomes/genes - tab "
+                          "separated in 2 or 3 columns [genome ID, genome fna, genome translation file (pep)]")
     ssu_finder_parser.add_argument(
         'output_dir', help="directory to write output files")
 
@@ -716,7 +733,9 @@ Example: checkm qa ./output/lineage.ms ./output
     merge_parser.add_argument(
         'marker_file', help="marker file to use for assessing potential bin mergers (marker set or HMM file)")
     merge_parser.add_argument(
-        'bin_dir', help="directory containing bins (fasta format)")
+        'bin_input', help="directory containing bins (fasta format) or "
+                          "path to file describing genomes/genes - tab "
+                          "separated in 2 or 3 columns [genome ID, genome fna, genome translation file (pep)]")
     merge_parser.add_argument(
         'output_dir', help="directory to write output files")
     merge_parser.add_argument('-g', '--genes', dest='bCalledGenes', action="store_true",
@@ -735,7 +754,6 @@ Example: checkm qa ./output/lineage.ms ./output
         '-t', '--threads', type=int, default=1, help="number of threads")
     merge_parser.add_argument('-q', '--quiet', dest='bQuiet',
                               action="store_true", default=False, help="suppress console output")
-
     # Identify outlier sequences
     outlier_parser = subparsers.add_parser('outliers',
                                            formatter_class=CustomHelpFormatter,
@@ -744,7 +762,9 @@ Example: checkm qa ./output/lineage.ms ./output
                                            description='Identify outliers in bins relative to reference distributions.',
                                            epilog='Example: checkm outliers ./output ./bins tetra.tsv outliers.tsv')
     outlier_parser.add_argument(
-        'bin_dir', help="directory containing bins (fasta format)")
+        'bin_input', help="directory containing bins (fasta format) or "
+                          "path to file describing genomes/genes - tab "
+                          "separated in 2 or 3 columns [genome ID, genome fna, genome translation file (pep)]")
     outlier_parser.add_argument(
         'tetra_profile', help='tetranucleotide profiles for each sequence (see tetra command)')
     outlier_parser.add_argument('output_file', help="print results to file")
@@ -781,7 +801,9 @@ Example: checkm qa ./output/lineage.ms ./output
                                           description='Ensure no sequences are assigned to multiple bins.',
                                           epilog='Example: checkm unique ./bins')
     unique_parser.add_argument(
-        'bin_dir', help="directory containing bins (fasta format)")
+        'bin_input', help="directory containing bins (fasta format) or "
+                          "path to file describing genomes/genes - tab "
+                          "separated in 2 or 3 columns [genome ID, genome fna, genome translation file (pep)]")
     unique_parser.add_argument('-x', '--extension', default='fna',
                                help="extension of bins (all other files in bin directory are ignored)")
 

--- a/checkm/common.py
+++ b/checkm/common.py
@@ -75,6 +75,31 @@ def checkEmptyDir(inputDir):
             sys.exit(1)
 
 
+def checkBinInputExists(binInput, bCalledGenes):
+    """Check if bin input exists."""
+    if os.path.isdir(binInput):
+        checkDirExists(binInput)
+    else:
+        checkFileExists(binInput)
+
+        binInput_ih = open(binInput)
+        binInput_oneline = binInput_ih.readline().strip().split("\t")
+        binInput_ih.close()
+
+        have_error = False
+        if bCalledGenes:
+            if len(binInput_oneline) < 3:
+                have_error = True
+        else:
+            if len(binInput_oneline) < 2:
+                have_error = True
+        if have_error:
+            logger = logging.getLogger("timestamp")
+            logger.error('Input table format is not correct: ' + binInput + '\n')
+            logger.error('If input is nucleotide contigs, please supply 2 column at least: [genome_id, genome_contigs_file]')
+            logger.error('If input is gene, please supply 3 column at least: [genome_id, genome_contigs_file, genome_genes_file]')
+
+
 def checkFileExists(inputFile):
     """Check if file exists."""
     if not os.path.exists(inputFile):

--- a/checkm/main.py
+++ b/checkm/main.py
@@ -38,7 +38,8 @@ from checkm.merger import Merger
 from checkm.profile import Profile
 from checkm.binTools import BinTools
 from checkm.ssuFinder import SSU_Finder
-from checkm.common import (makeSurePathExists,
+from checkm.common import (checkBinInputExists,
+                           makeSurePathExists,
                            checkFileExists,
                            binIdFromFilename,
                            getBinIdsFromOutDir,
@@ -79,22 +80,50 @@ class OptionsParser():
             self.logger.error(
                 'Path to the CheckM reference data must be specified.')
 
-    def binFiles(self, binFolder, binExtension):
+    def binFiles(self, binInput, binExtension, bCalledGenes):
         binFiles = []
-        if binFolder is not None:
-            all_files = os.listdir(binFolder)
-            for f in all_files:
-                if f.endswith(binExtension):
-                    binFile = os.path.join(binFolder, f)
-                    if os.stat(binFile).st_size == 0:
-                        self.logger.warning(
-                            "Skipping bin %s as it has a size of 0 bytes." % f)
-                    else:
-                        binFiles.append(binFile)
+        binIDs = set()
+        isInputDir = True
+        if binInput is not None:
+            if os.path.isdir(binInput):
+                all_files = os.listdir(binInput)
+                for f in all_files:
+                    if f.endswith(binExtension):
+                        binFile = os.path.join(binInput, f)
+                        if os.stat(binFile).st_size == 0:
+                            self.logger.warning(
+                                "Skipping bin %s as it has a size of 0 bytes." % f)
+                        else:
+                            binFiles.append(binFile)
+                            binIDs.add(os.path.basename(binFile))
+            else:
+                with open(binInput, "r") as oh:
+                    for line in oh:
+                        files = line.strip().split("\t")
+                        binFile = files[1]
+                        if bCalledGenes:
+                            binFile = files[2]
+                        if not os.path.exists(binFile):
+                            self.logger.warning(
+                                "Skipping bin %s as it doesn't exists." % f)
+                        elif os.stat(binFile).st_size == 0:
+                            self.logger.warning(
+                                "Skipping bin %s as it has a size of 0 bytes." % f)
+                        else:
+                            binFiles.append(binFile)
+                            binIDs.add(os.path.basename(binFile))
 
         if not binFiles:
-            self.logger.error(
-                "No bins found. Check the extension (-x) used to identify bins.")
+            if isInputDir:
+                self.logger.error(
+                    "No bins found. Check the extension (-x) used to identify bins.")
+            else:
+                self.logger.error(
+                    "No binsfound. Check the bins input table to identify bins turely exists")
+            sys.exit(1)
+
+        if len(binIDs) != len(binFiles):
+            self.logger.error("There are redundant bin ID, please check and update it")
             sys.exit(1)
 
         return sorted(binFiles)
@@ -104,7 +133,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - tree] Placing bins in reference genome tree.')
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         if not options.bCalledGenes:
             if not checkNuclotideSeqs(binFiles):
@@ -265,7 +294,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - analyze] Identifying marker genes in bins.')
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         if not options.bCalledGenes:
             if not checkNuclotideSeqs(binFiles):
@@ -427,10 +456,10 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - gc_plot] Creating GC histogram and delta-GC plot.')
 
-        checkDirExists(options.bin_dir)
+        checkBinInputExists(options.bin_input)
         makeSurePathExists(options.output_dir)
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         plots = GcPlots(options)
         filesProcessed = 1
@@ -454,10 +483,10 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - coding_plot] Creating coding density histogram and delta-CD plot.')
 
-        checkDirExists(options.bin_dir)
+        checkBinInputExists(options.bin_input)
         makeSurePathExists(options.output_dir)
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         plots = CodingDensityPlots(options)
         filesProcessed = 1
@@ -481,10 +510,10 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - tetra_plot] Creating tetra-distance histogram and delta-TD plot.')
 
-        checkDirExists(options.bin_dir)
+        checkBinInputExists(options.bin_input)
         makeSurePathExists(options.output_dir)
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         genomicSignatures = GenomicSignatures(K=4, threads=1)
         tetraSigs = genomicSignatures.read(options.tetra_profile)
@@ -511,10 +540,10 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - dist_plot] Creating GC, CD, and TD distribution plots.')
 
-        checkDirExists(options.bin_dir)
+        checkBinInputExists(options.bin_input)
         makeSurePathExists(options.output_dir)
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         genomicSignatures = GenomicSignatures(K=4, threads=1)
         tetraSigs = genomicSignatures.read(options.tetra_profile)
@@ -542,10 +571,10 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - gc_bias_plot] Plotting bin coverage as a function of GC.')
 
-        checkDirExists(options.bin_dir)
+        checkBinInputExists(options.bin_input)
         makeSurePathExists(options.output_dir)
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         coverageWindows = CoverageWindows(options.threads)
         coverageProfile = coverageWindows.run(
@@ -573,10 +602,10 @@ class OptionsParser():
 
         self.logger.info('[CheckM - nx_plot] Creating Nx-plots.')
 
-        checkDirExists(options.bin_dir)
+        checkBinInputExists(options.bin_input)
         makeSurePathExists(options.output_dir)
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         nx = NxPlot(options)
         filesProcessed = 1
@@ -600,10 +629,10 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - len_hist] Creating sequence length histogram.')
 
-        checkDirExists(options.bin_dir)
+        checkBinInputExists(options.bin_input)
         makeSurePathExists(options.output_dir)
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         plot = LengthHistogram(options)
         filesProcessed = 1
@@ -627,11 +656,11 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - marker_plot] Creating marker gene position plot.')
 
-        checkDirExists(options.bin_dir)
+        checkBinInputExists(options.bin_input)
         makeSurePathExists(options.output_dir)
 
         # generate plot for each bin
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         resultsParser = ResultsParser(None)
         markerGeneStats = resultsParser.parseMarkerGeneStats(
@@ -666,9 +695,9 @@ class OptionsParser():
 
         self.logger.info('[CheckM - unbinned] Identify unbinned sequences.')
 
-        checkDirExists(options.bin_dir)
+        checkBinInputExists(options.bin_input)
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         unbinned = Unbinned()
         unbinned.run(binFiles, options.seq_file, options.output_seq_file,
@@ -687,10 +716,10 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - coverage] Calculating coverage of sequences.')
 
-        checkDirExists(options.bin_dir)
+        checkBinInputExists(options.bin_input)
         makeSurePathExists(os.path.dirname(options.output_file))
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         coverage = Coverage(options.threads)
         coverage.run(binFiles, options.bam_files, options.output_file, options.all_reads,
@@ -740,9 +769,9 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - merge] Identifying bins with complementary sets of marker genes.')
 
-        checkDirExists(options.bin_dir)
+        checkBinInputExists(options.bin_input)
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         if not options.bCalledGenes:
             if not checkNuclotideSeqs(binFiles):
@@ -798,11 +827,11 @@ class OptionsParser():
 
         self.logger.info('[CheckM - outlier] Identifying outliers in bins.')
 
-        checkDirExists(options.bin_dir)
+        checkBinInputExists(options.bin_input)
         checkFileExists(options.tetra_profile)
         makeSurePathExists(os.path.dirname(options.output_file))
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         binTools = BinTools()
         binTools.identifyOutliers(options.results_dir,
@@ -852,7 +881,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - unique] Ensuring no sequences are assigned to multiple bins.')
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         binTools = BinTools()
         binTools.unique(binFiles)
@@ -865,7 +894,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - ssu_finder] Identifying SSU (16S/18S) rRNAs in sequences.')
 
-        binFiles = self.binFiles(options.bin_dir, options.extension)
+        binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
         checkFileExists(options.seq_file)
         makeSurePathExists(options.output_dir)

--- a/checkm/main.py
+++ b/checkm/main.py
@@ -456,7 +456,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - gc_plot] Creating GC histogram and delta-GC plot.')
 
-        checkBinInputExists(options.bin_input)
+        checkBinInputExists(options.bin_input, options.bCalledGenes)
         makeSurePathExists(options.output_dir)
 
         binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
@@ -483,7 +483,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - coding_plot] Creating coding density histogram and delta-CD plot.')
 
-        checkBinInputExists(options.bin_input)
+        checkBinInputExists(options.bin_input, options.bCalledGenes)
         makeSurePathExists(options.output_dir)
 
         binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
@@ -510,7 +510,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - tetra_plot] Creating tetra-distance histogram and delta-TD plot.')
 
-        checkBinInputExists(options.bin_input)
+        checkBinInputExists(options.bin_input, options.bCalledGenes)
         makeSurePathExists(options.output_dir)
 
         binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
@@ -540,7 +540,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - dist_plot] Creating GC, CD, and TD distribution plots.')
 
-        checkBinInputExists(options.bin_input)
+        checkBinInputExists(options.bin_input, options.bCalledGenes)
         makeSurePathExists(options.output_dir)
 
         binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
@@ -571,7 +571,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - gc_bias_plot] Plotting bin coverage as a function of GC.')
 
-        checkBinInputExists(options.bin_input)
+        checkBinInputExists(options.bin_input, options.bCalledGenes)
         makeSurePathExists(options.output_dir)
 
         binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
@@ -602,7 +602,7 @@ class OptionsParser():
 
         self.logger.info('[CheckM - nx_plot] Creating Nx-plots.')
 
-        checkBinInputExists(options.bin_input)
+        checkBinInputExists(options.bin_input, options.bCalledGenes)
         makeSurePathExists(options.output_dir)
 
         binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
@@ -629,7 +629,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - len_hist] Creating sequence length histogram.')
 
-        checkBinInputExists(options.bin_input)
+        checkBinInputExists(options.bin_input, options.bCalledGenes)
         makeSurePathExists(options.output_dir)
 
         binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
@@ -656,7 +656,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - marker_plot] Creating marker gene position plot.')
 
-        checkBinInputExists(options.bin_input)
+        checkBinInputExists(options.bin_input, options.bCalledGenes)
         makeSurePathExists(options.output_dir)
 
         # generate plot for each bin
@@ -695,7 +695,7 @@ class OptionsParser():
 
         self.logger.info('[CheckM - unbinned] Identify unbinned sequences.')
 
-        checkBinInputExists(options.bin_input)
+        checkBinInputExists(options.bin_input, options.bCalledGenes)
 
         binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
@@ -716,7 +716,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - coverage] Calculating coverage of sequences.')
 
-        checkBinInputExists(options.bin_input)
+        checkBinInputExists(options.bin_input, options.bCalledGenes)
         makeSurePathExists(os.path.dirname(options.output_file))
 
         binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
@@ -769,7 +769,7 @@ class OptionsParser():
         self.logger.info(
             '[CheckM - merge] Identifying bins with complementary sets of marker genes.')
 
-        checkBinInputExists(options.bin_input)
+        checkBinInputExists(options.bin_input, options.bCalledGenes)
 
         binFiles = self.binFiles(options.bin_input, options.extension, options.bCalledGenes)
 
@@ -827,7 +827,7 @@ class OptionsParser():
 
         self.logger.info('[CheckM - outlier] Identifying outliers in bins.')
 
-        checkBinInputExists(options.bin_input)
+        checkBinInputExists(options.bin_input, options.bCalledGenes)
         checkFileExists(options.tetra_profile)
         makeSurePathExists(os.path.dirname(options.output_file))
 

--- a/checkm/test/test_ecoli.py
+++ b/checkm/test/test_ecoli.py
@@ -62,7 +62,7 @@ class VerifyEcoli():
         options.bNucORFs = False
         options.bCalledGenes = False
         options.bReducedTree = True
-        options.bin_dir = os.path.join(DefaultValues.CHECKM_DATA_DIR, 'test_data')
+        options.bin_input = os.path.join(DefaultValues.CHECKM_DATA_DIR, 'test_data')
         parser.tree(options)
         self.verifyTree(options.output_dir)
         self.logger.info('[Passed]')


### PR DESCRIPTION
When we assembled a very large number of MAGs from multiple samples with multiple binners, these MAGs were stored in different directories. If we wanted to run checkm at one time, we had to link these MAGs to one directory. 

Request support for table as input to checkm, so we only need to provide a table with 2 or 3 columns (genes) to run checkm.