### PR TITLE
avoid UnboundLocalError

### DIFF
--- a/checkm/main.py
+++ b/checkm/main.py
@@ -108,10 +108,10 @@ class OptionsParser():
                             binFile = files[2]
                         if not os.path.exists(binFile):
                             self.logger.warning(
-                                "Skipping bin %s as it doesn't exists." % f)
+                                "Skipping bin %s as it doesn't exists." % binFile)
                         elif os.stat(binFile).st_size == 0:
                             self.logger.warning(
-                                "Skipping bin %s as it has a size of 0 bytes." % f)
+                                "Skipping bin %s as it has a size of 0 bytes." % binFile)
                         else:
                             binFiles.append(binFile)
                             binIDs.add(os.path.basename(binFile))


### PR DESCRIPTION
```
  File "/home/jiezhu/.conda/envs/d58667f94249616af20d0c1b8d950528/lib/python3.9/site-packages/checkm/main.py", line 111, in binFiles
    "Skipping bin %s as it doesn't exists." % f)
UnboundLocalError: local variable 'f' referenced before assignment
```

Now, fixed.