### PR TITLE
Rename private class methods

### DIFF
--- a/checkm/binStatistics.py
+++ b/checkm/binStatistics.py
@@ -76,8 +76,8 @@ class BinStatistics():
             workerQueue.put(None)
 
         try:
-            calcProc = [mp.Process(target=self.__processBin, args=(outDir, workerQueue, writerQueue)) for _ in range(self.totalThreads)]
-            writeProc = mp.Process(target=self.__reportProgress, args=(outDir, binStatsFile, len(binFiles), writerQueue))
+            calcProc = [mp.Process(target=self._processBin, args=(outDir, workerQueue, writerQueue)) for _ in range(self.totalThreads)]
+            writeProc = mp.Process(target=self._reportProgress, args=(outDir, binStatsFile, len(binFiles), writerQueue))
 
             writeProc.start()
 
@@ -96,7 +96,7 @@ class BinStatistics():
 
             writeProc.terminate()
 
-    def __processBin(self, outDir, queueIn, queueOut):
+    def _processBin(self, outDir, queueIn, queueOut):
         """Thread safe bin processing."""
         while True:
             binFile = queueIn.get(block=True, timeout=None)
@@ -138,7 +138,7 @@ class BinStatistics():
 
             queueOut.put((binId, binStats))
 
-    def __reportProgress(self, outDir, binStatsFile, numBins, queueIn):
+    def _reportProgress(self, outDir, binStatsFile, numBins, queueIn):
         """Report number of processed bins and write statistics to file."""
 
         storagePath = os.path.join(outDir, 'storage')
@@ -242,7 +242,7 @@ class BinStatistics():
             aaFile = os.path.join(outDir, DefaultValues.PRODIGAL_AA)  # use AA file as nucleotide file is optional
             aaGenes = readFasta(aaFile)
 
-            codingBasePairs = 0  # self.__calculateCodingBases(aaGenes)
+            codingBasePairs = 0  # self._calculateCodingBases(aaGenes)
             for scaffold_id in scaffolds.keys():
                 codingBasePairs += prodigalParserGFF.codingBases(scaffold_id)
 
@@ -252,7 +252,7 @@ class BinStatistics():
             # so calculating the coding density is not possible
             return -1, -1, -1
 
-    def __calculateCodingBases(self, aaGenes):
+    def _calculateCodingBases(self, aaGenes):
         """Calculate number of coding bases in a set of genes."""
         codingBasePairs = 0
         for _geneId, gene in aaGenes.items():

--- a/checkm/binTools.py
+++ b/checkm/binTools.py
@@ -38,7 +38,7 @@ class BinTools():
     def __init__(self, threads=1):
         self.logger = logging.getLogger('timestamp')
 
-    def __removeSeqs(self, seqs, seqsToRemove):
+    def _removeSeqs(self, seqs, seqsToRemove):
         """Remove sequences. """
         missingSeqIds = set(seqsToRemove).difference(set(seqs.keys()))
         if len(missingSeqIds) > 0:
@@ -48,7 +48,7 @@ class BinTools():
         for seqId in seqsToRemove:
             seqs.pop(seqId)
 
-    def __addSeqs(self, seqs, refSeqs, seqsToAdd):
+    def _addSeqs(self, seqs, refSeqs, seqsToAdd):
         """Add sequences. """
         missingSeqIds = set(seqsToAdd).difference(set(refSeqs.keys()))
         if len(missingSeqIds) > 0:
@@ -65,11 +65,11 @@ class BinTools():
         # add sequences to bin
         if seqsToAdd != None:
             refSeqs = readFasta(seqFile)
-            self.__addSeqs(binSeqs, refSeqs, seqsToAdd)
+            self._addSeqs(binSeqs, refSeqs, seqsToAdd)
 
         # remove sequences from bin
         if seqsToRemove != None:
-            self.__removeSeqs(binSeqs, seqsToRemove)
+            self._removeSeqs(binSeqs, seqsToRemove)
 
         # save modified bin
         writeFasta(binSeqs, outputFile)
@@ -98,7 +98,7 @@ class BinTools():
 
         # remove sequences from bin
         if len(seqsToRemove) > 0:
-            self.__removeSeqs(binSeqs, seqsToRemove)
+            self._removeSeqs(binSeqs, seqsToRemove)
 
         # save modified bin
         writeFasta(binSeqs, outputFile)

--- a/checkm/coverage.py
+++ b/checkm/coverage.py
@@ -84,7 +84,7 @@ class Coverage():
             self.logger.info('Processing %s (%d of %d):' % (ntpath.basename(bamFile), numFilesStarted, len(bamFiles)))
 
             coverageInfo[bamFile] = mp.Manager().dict()
-            coverageInfo[bamFile] = self.__processBam(bamFile, bAllReads, minAlignPer, maxEditDistPer, minQC, coverageInfo[bamFile])
+            coverageInfo[bamFile] = self._processBam(bamFile, bAllReads, minAlignPer, maxEditDistPer, minQC, coverageInfo[bamFile])
 
         # redirect output
         self.logger.info('Writing coverage information to file.')
@@ -117,7 +117,7 @@ class Coverage():
         # restore stdout
         restoreStdOut(outFile, oldStdOut)
 
-    def __processBam(self, bamFile, bAllReads, minAlignPer, maxEditDistPer, minQC, coverageInfo):
+    def _processBam(self, bamFile, bAllReads, minAlignPer, maxEditDistPer, minQC, coverageInfo):
         """Calculate coverage of sequences in BAM file."""
 
         # determine coverage for each reference sequence

--- a/checkm/coverageWindows.py
+++ b/checkm/coverageWindows.py
@@ -100,11 +100,11 @@ class CoverageWindows():
         # calculate coverage of each BAM file
         self.logger.info('Calculating coverage of windows.')
         coverageInfo = mp.Manager().dict()
-        coverageInfo = self.__processBam(bamFile, bAllReads, minAlignPer, maxEditDistPer, windowSize, coverageInfo)
+        coverageInfo = self._processBam(bamFile, bAllReads, minAlignPer, maxEditDistPer, windowSize, coverageInfo)
 
         return coverageInfo
 
-    def __processBam(self, bamFile, bAllReads, minAlignPer, maxEditDistPer, windowSize, coverageInfo):
+    def _processBam(self, bamFile, bAllReads, minAlignPer, maxEditDistPer, windowSize, coverageInfo):
         """Calculate coverage of sequences in BAM file."""
 
         # determine coverage for each reference sequence
@@ -143,8 +143,8 @@ class CoverageWindows():
             workerQueue.put((None, None))
 
         try:
-            workerProc = [mp.Process(target=self.__workerThread, args=(bamFile, bAllReads, minAlignPer, maxEditDistPer, windowSize, workerQueue, writerQueue)) for _ in range(self.totalThreads)]
-            writeProc = mp.Process(target=self.__writerThread, args=(coverageInfo, len(refSeqIds), writerQueue))
+            workerProc = [mp.Process(target=self._workerThread, args=(bamFile, bAllReads, minAlignPer, maxEditDistPer, windowSize, workerQueue, writerQueue)) for _ in range(self.totalThreads)]
+            writeProc = mp.Process(target=self._writerThread, args=(coverageInfo, len(refSeqIds), writerQueue))
 
             writeProc.start()
 
@@ -165,7 +165,7 @@ class CoverageWindows():
 
         return coverageInfo
 
-    def __workerThread(self, bamFile, bAllReads, minAlignPer, maxEditDistPer, windowSize, queueIn, queueOut):
+    def _workerThread(self, bamFile, bAllReads, minAlignPer, maxEditDistPer, windowSize, queueIn, queueOut):
         """Process each data item in parallel."""
         while True:
             seqIds, seqLens = queueIn.get(block=True, timeout=None)
@@ -202,7 +202,7 @@ class CoverageWindows():
 
             bamfile.close()
 
-    def __writerThread(self, coverageInfo, numRefSeqs, writerQueue):
+    def _writerThread(self, coverageInfo, numRefSeqs, writerQueue):
         """Store or write results of worker threads in a single thread."""
         totalReads = 0
         totalDuplicates = 0

--- a/checkm/genomicSignatures.py
+++ b/checkm/genomicSignatures.py
@@ -37,11 +37,11 @@ class GenomicSignatures(object):
 
         self.K = K
         self.compl = str.maketrans('ACGT', 'TGCA')
-        self.kmerCols, self.kmerToCanonicalIndex = self.__makeKmerColNames()
+        self.kmerCols, self.kmerToCanonicalIndex = self._makeKmerColNames()
 
         self.totalThreads = threads
 
-    def __makeKmerColNames(self):
+    def _makeKmerColNames(self):
         """Work out unique kmers."""
 
         # determine all mers of a given length
@@ -57,7 +57,7 @@ class GenomicSignatures(object):
         # pare down kmers based on lexicographical ordering
         retList = []
         for mer in mers:
-            kmer = self.__lexicographicallyLowest(mer)
+            kmer = self._lexicographicallyLowest(mer)
             if kmer not in retList:
                 retList.append(kmer)
 
@@ -67,23 +67,23 @@ class GenomicSignatures(object):
         kmerToCanonicalIndex = {}
         for index, kmer in enumerate(retList):
             kmerToCanonicalIndex[kmer] = index
-            kmerToCanonicalIndex[self.__revComp(kmer)] = index
+            kmerToCanonicalIndex[self._revComp(kmer)] = index
 
         return retList, kmerToCanonicalIndex
 
-    def __lexicographicallyLowest(self, seq):
+    def _lexicographicallyLowest(self, seq):
         """Return the lexicographically lowest form of this sequence."""
-        rseq = self.__revComp(seq)
+        rseq = self._revComp(seq)
         if(seq < rseq):
             return seq
         return rseq
 
-    def __revComp(self, seq):
+    def _revComp(self, seq):
         """Return the reverse complement of a sequence."""
         # build a dictionary to know what letter to switch to
         return seq.translate(self.compl)[::-1]
 
-    def __calculateResults(self, queueIn, queueOut):
+    def _calculateResults(self, queueIn, queueOut):
         """Calculate genomic signature of sequences in parallel."""
         while True:
             seqId, seq = queueIn.get(block=True, timeout=None)
@@ -94,7 +94,7 @@ class GenomicSignatures(object):
 
             queueOut.put((seqId, sig))
 
-    def __storeResults(self, seqFile, outputFile, totalSeqs, writerQueue):
+    def _storeResults(self, seqFile, outputFile, totalSeqs, writerQueue):
         """Store genomic signatures to file."""
 
         # write header
@@ -166,8 +166,8 @@ class GenomicSignatures(object):
             workerQueue.put((None, None))
 
         try:
-            calcProc = [mp.Process(target=self.__calculateResults, args=(workerQueue, writerQueue)) for _ in range(self.totalThreads)]
-            writeProc = mp.Process(target=self.__storeResults, args=(seqFile, outputFile, len(seqs), writerQueue))
+            calcProc = [mp.Process(target=self._calculateResults, args=(workerQueue, writerQueue)) for _ in range(self.totalThreads)]
+            writeProc = mp.Process(target=self._storeResults, args=(seqFile, outputFile, len(seqs), writerQueue))
 
             writeProc.start()
 

--- a/checkm/hmmerAligner.py
+++ b/checkm/hmmerAligner.py
@@ -65,16 +65,16 @@ class HmmerAligner:
         resultsParser.parseBinHits(outDir, hmmTableFile, False, bIgnoreThresholds, evalueThreshold, lengthThreshold)
 
         # extract the ORFs to align
-        markerSeqs, markerStats = self.__extractMarkerSeqsTopHits(outDir, resultsParser)
+        markerSeqs, markerStats = self._extractMarkerSeqsTopHits(outDir, resultsParser)
 
         # generate individual HMMs required to create multiple sequence alignments
         binId = list(binIdToModels.keys())[0]
         hmmModelFiles = {}
-        self.__makeAlignmentModels(hmmModelFile, binIdToModels[binId], hmmModelFiles)
+        self._makeAlignmentModels(hmmModelFile, binIdToModels[binId], hmmModelFiles)
 
         # align each of the marker genes
         makeSurePathExists(alignOutputDir)
-        self.__alignMarkerGenes(markerSeqs, markerStats, bReportHitStats, hmmModelFiles, alignOutputDir, bKeepUnmaskedAlign)
+        self._alignMarkerGenes(markerSeqs, markerStats, bReportHitStats, hmmModelFiles, alignOutputDir, bKeepUnmaskedAlign)
 
         # remove the temporary HMM files
         for fileName in hmmModelFiles:
@@ -105,16 +105,16 @@ class HmmerAligner:
         resultsParser.parseBinHits(outDir, hmmTableFile, False, bIgnoreThresholds, evalueThreshold, lengthThreshold)
 
         # extract the ORFs to align
-        markerSeqs, markerStats = self.__extractMarkerSeqsUnique(outDir, resultsParser)
+        markerSeqs, markerStats = self._extractMarkerSeqsUnique(outDir, resultsParser)
 
         # generate individual HMMs required to create multiple sequence alignments
         binId = list(binIdToModels.keys())[0]
         hmmModelFiles = {}
-        self.__makeAlignmentModels(hmmModelFile, binIdToModels[binId], hmmModelFiles)
+        self._makeAlignmentModels(hmmModelFile, binIdToModels[binId], hmmModelFiles)
 
         # align each of the marker genes
         makeSurePathExists(alignOutputDir)
-        self.__alignMarkerGenes(markerSeqs, markerStats, bReportHitStats, hmmModelFiles, alignOutputDir, bKeepUnmaskedAlign)
+        self._alignMarkerGenes(markerSeqs, markerStats, bReportHitStats, hmmModelFiles, alignOutputDir, bKeepUnmaskedAlign)
 
         # remove the temporary HMM files
         for fileName in hmmModelFiles:
@@ -157,8 +157,8 @@ class HmmerAligner:
             workerQueue.put(None)
 
         try:
-            calcProc = [mp.Process(target=self.__createMSA, args=(resultsParser, binIdToBinMarkerSets, markerFile, outDir, alignOutputDir, workerQueue, writerQueue)) for _ in range(self.totalThreads)]
-            writeProc = mp.Process(target=self.__reportBinProgress, args=(len(binIdToModels), writerQueue))
+            calcProc = [mp.Process(target=self._createMSA, args=(resultsParser, binIdToBinMarkerSets, markerFile, outDir, alignOutputDir, workerQueue, writerQueue)) for _ in range(self.totalThreads)]
+            writeProc = mp.Process(target=self._reportBinProgress, args=(len(binIdToModels), writerQueue))
 
             writeProc.start()
 
@@ -177,7 +177,7 @@ class HmmerAligner:
 
             writeProc.terminate()
 
-    def __createMSA(self, resultsParser, binIdToBinMarkerSets, hmmModelFile, outDir, alignOutputDir, queueIn, queueOut):
+    def _createMSA(self, resultsParser, binIdToBinMarkerSets, hmmModelFile, outDir, alignOutputDir, queueIn, queueOut):
         """Create multiple sequence alignment for markers with multiple hits in a bin."""
 
         HF = HMMERRunner(mode='fetch')
@@ -187,7 +187,7 @@ class HmmerAligner:
             if binId == None:
                 break
 
-            markersWithMultipleHits = self.__extractMarkersWithMultipleHits(outDir, binId, resultsParser, binIdToBinMarkerSets[binId])
+            markersWithMultipleHits = self._extractMarkersWithMultipleHits(outDir, binId, resultsParser, binIdToBinMarkerSets[binId])
 
             if len(markersWithMultipleHits) != 0:
                 # create multiple sequence alignments for markers with multiple hits
@@ -197,13 +197,13 @@ class HmmerAligner:
                     tempModelFile = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))
                     HF.fetch(hmmModelFile, markerId, tempModelFile)
 
-                    self.__alignMarker(markerId, markersWithMultipleHits[markerId], None, False, binAlignOutputDir, tempModelFile, bKeepUnmaskedAlign=False)
+                    self._alignMarker(markerId, markersWithMultipleHits[markerId], None, False, binAlignOutputDir, tempModelFile, bKeepUnmaskedAlign=False)
 
                     os.remove(tempModelFile)
 
             queueOut.put(binId)
 
-    def __reportBinProgress(self, numBins, queueIn):
+    def _reportBinProgress(self, numBins, queueIn):
         """Report number of processed bins."""
 
         numProcessedBins = 0
@@ -226,7 +226,7 @@ class HmmerAligner:
         if self.logger.getEffectiveLevel() <= logging.INFO:
             sys.stderr.write('\n')
 
-    def __alignMarkerGenes(self, markerSeqs, markerStats, bReportHitStats, hmmModelFiles, alignOutputDir, bKeepUnmaskedAlign=False, bReportProgress=True):
+    def _alignMarkerGenes(self, markerSeqs, markerStats, bReportHitStats, hmmModelFiles, alignOutputDir, bKeepUnmaskedAlign=False, bReportProgress=True):
         """Align marker genes with HMMs in parallel."""
 
         if bReportProgress:
@@ -243,8 +243,8 @@ class HmmerAligner:
             workerQueue.put(None)
 
         try:
-            calcProc = [mp.Process(target=self.__alignMarkerParallel, args=(markerSeqs, markerStats, bReportHitStats, alignOutputDir, hmmModelFiles, bKeepUnmaskedAlign, workerQueue, writerQueue)) for _ in range(self.totalThreads)]
-            writeProc = mp.Process(target=self.__reportAlignmentProgress, args=(len(hmmModelFiles), bReportProgress, writerQueue))
+            calcProc = [mp.Process(target=self._alignMarkerParallel, args=(markerSeqs, markerStats, bReportHitStats, alignOutputDir, hmmModelFiles, bKeepUnmaskedAlign, workerQueue, writerQueue)) for _ in range(self.totalThreads)]
+            writeProc = mp.Process(target=self._reportAlignmentProgress, args=(len(hmmModelFiles), bReportProgress, writerQueue))
 
             writeProc.start()
 
@@ -263,17 +263,17 @@ class HmmerAligner:
 
             writeProc.terminate()
 
-    def __alignMarkerParallel(self, markerSeqs, markerStats, bReportHitStats, alignOutputDir, hmmModelFiles, bKeepUnmaskedAlign, queueIn, queueOut):
+    def _alignMarkerParallel(self, markerSeqs, markerStats, bReportHitStats, alignOutputDir, hmmModelFiles, bKeepUnmaskedAlign, queueIn, queueOut):
         while True:
             markerId = queueIn.get(block=True, timeout=None)
             if markerId == None:
                 break
 
-            self.__alignMarker(markerId, markerSeqs[markerId], markerStats[markerId], bReportHitStats, alignOutputDir, hmmModelFiles[markerId], bKeepUnmaskedAlign)
+            self._alignMarker(markerId, markerSeqs[markerId], markerStats[markerId], bReportHitStats, alignOutputDir, hmmModelFiles[markerId], bKeepUnmaskedAlign)
 
             queueOut.put(markerId)
 
-    def __alignMarker(self, markerId, binSeqs, binStats, bReportHitStats, alignOutputDir, hmmModelFile, bKeepUnmaskedAlign):
+    def _alignMarker(self, markerId, binSeqs, binStats, bReportHitStats, alignOutputDir, hmmModelFile, bKeepUnmaskedAlign):
         unalignSeqFile = os.path.join(alignOutputDir, markerId + '.unaligned.faa')
         fout = open(unalignSeqFile, 'w')
         numSeqs = 0
@@ -294,14 +294,14 @@ class HmmerAligner:
             HA.align(hmmModelFile, unalignSeqFile, alignSeqFile, writeMode='>', outputFormat=self.outputFormat, trim=False)
 
             makedSeqFile = os.path.join(alignOutputDir, markerId + '.masked.faa')
-            self.__maskAlignment(alignSeqFile, makedSeqFile)
+            self._maskAlignment(alignSeqFile, makedSeqFile)
 
             if not bKeepUnmaskedAlign:
                 os.remove(alignSeqFile)
 
         os.remove(unalignSeqFile)
 
-    def __reportAlignmentProgress(self, numMarkers, bReportProgress, queueIn):
+    def _reportAlignmentProgress(self, numMarkers, bReportProgress, queueIn):
         """Report number of processed markers."""
 
         numProcessedGenes = 0
@@ -324,7 +324,7 @@ class HmmerAligner:
         if bReportProgress and self.logger.getEffectiveLevel() <= logging.INFO:
             sys.stderr.write('\n')
 
-    def __maskAlignment(self, inputFile, outputFile):
+    def _maskAlignment(self, inputFile, outputFile):
         """Read HMMER alignment in STOCKHOLM format and output masked alignment in FASTA format."""
         # read STOCKHOLM alignment
         seqs = {}
@@ -357,7 +357,7 @@ class HmmerAligner:
             fout.write(maskedSeq + '\n')
         fout.close()
 
-    def __extractMarkerSeqsTopHits(self, outDir, resultsParser):
+    def _extractMarkerSeqsTopHits(self, outDir, resultsParser):
         """Extract marker sequences from top hits (assume all bins use the same HMM file)."""
 
         markerSeqs = defaultdict(dict)
@@ -376,12 +376,12 @@ class HmmerAligner:
                 # to a given target is retained
                 hits.sort(key=lambda x: x.full_e_value, reverse=True)
                 topHit = hits[0]
-                markerSeqs[markerId][binId][topHit.target_name] = self.__extractSeq(topHit.target_name, binORFs)
+                markerSeqs[markerId][binId][topHit.target_name] = self._extractSeq(topHit.target_name, binORFs)
                 markerStats[markerId][binId][topHit.target_name] = [topHit.full_e_value, topHit.full_score]
 
         return markerSeqs, markerStats
 
-    def __extractMarkerSeqsUnique(self, outDir, resultsParser):
+    def _extractMarkerSeqsUnique(self, outDir, resultsParser):
         """Extract marker sequences with a single unique hit."""
 
         markerSeqs = defaultdict(dict)
@@ -399,12 +399,12 @@ class HmmerAligner:
                 # only record hits which are unique
                 if len(hits) == 1:
                     hit = hits[0]
-                    markerSeqs[markerId][binId][hit.target_name] = self.__extractSeq(hit.target_name, binORFs)
+                    markerSeqs[markerId][binId][hit.target_name] = self._extractSeq(hit.target_name, binORFs)
                     markerStats[markerId][binId][hit.target_name] = [hit.full_e_value, hit.full_score]
 
         return markerSeqs, markerStats
 
-    def __extractSeq(self, seqId, seqs):
+    def _extractSeq(self, seqId, seqs):
         """Extract sequence data."""
 
         if DefaultValues.SEQ_CONCAT_CHAR in seqId:
@@ -427,7 +427,7 @@ class HmmerAligner:
 
         return rtnSeq
 
-    def __extractMarkersWithMultipleHits(self, outDir, binId, resultsParser, binMarkerSet):
+    def _extractMarkersWithMultipleHits(self, outDir, binId, resultsParser, binMarkerSet):
         """Extract markers with multiple hits within a single bin."""
 
         markersWithMultipleHits = defaultdict(dict)
@@ -444,14 +444,14 @@ class HmmerAligner:
             # to a given target is retained
             hits.sort(key=lambda x: x.full_e_value, reverse=True)
 
-            # Note: this data structure is used to mimic that used by __extractMarkerSeqsTopHits()
+            # Note: this data structure is used to mimic that used by _extractMarkerSeqsTopHits()
             markersWithMultipleHits[markerId][binId] = {}
             for hit in hits:
-                markersWithMultipleHits[markerId][binId][hit.target_name] = self.__extractSeq(hit.target_name, binORFs)
+                markersWithMultipleHits[markerId][binId][hit.target_name] = self._extractSeq(hit.target_name, binORFs)
 
         return markersWithMultipleHits
 
-    def __makeAlignmentModels(self, hmmModelFile, modelKeys, hmmModelFiles, bReportProgress=True):
+    def _makeAlignmentModels(self, hmmModelFile, modelKeys, hmmModelFiles, bReportProgress=True):
         """Make temporary HMM files used to create HMM alignments."""
 
         if bReportProgress:
@@ -470,8 +470,8 @@ class HmmerAligner:
             workerQueue.put((None, None))
 
         try:
-            calcProc = [mp.Process(target=self.__extractModel, args=(hmmModelFile, workerQueue, writerQueue)) for _ in range(self.totalThreads)]
-            writeProc = mp.Process(target=self.__reportModelExtractionProgress, args=(len(modelKeys), bReportProgress, writerQueue))
+            calcProc = [mp.Process(target=self._extractModel, args=(hmmModelFile, workerQueue, writerQueue)) for _ in range(self.totalThreads)]
+            writeProc = mp.Process(target=self._reportModelExtractionProgress, args=(len(modelKeys), bReportProgress, writerQueue))
 
             writeProc.start()
 
@@ -490,7 +490,7 @@ class HmmerAligner:
 
             writeProc.terminate()
 
-    def __extractModel(self, hmmModelFile, queueIn, queueOut):
+    def _extractModel(self, hmmModelFile, queueIn, queueOut):
         """Extract HMM."""
         HF = HMMERRunner(mode='fetch')
 
@@ -503,7 +503,7 @@ class HmmerAligner:
 
             queueOut.put(modelId)
 
-    def __reportModelExtractionProgress(self, numMarkers, bReportProgress, queueIn):
+    def _reportModelExtractionProgress(self, numMarkers, bReportProgress, queueIn):
         """Report number of extracted HMMs."""
 
         numModelsExtracted = 0

--- a/checkm/markerGeneFinder.py
+++ b/checkm/markerGeneFinder.py
@@ -67,8 +67,8 @@ class MarkerGeneFinder():
         binIdToModels = mp.Manager().dict()
 
         try:
-            calcProc = [mp.Process(target=self.__processBin, args=(outDir, tableOut, hmmerOut, markerFile, bKeepAlignment, bNucORFs, bCalledGenes, workerQueue, writerQueue)) for _ in range(self.totalThreads)]
-            writeProc = mp.Process(target=self.__reportProgress, args=(len(binFiles), binIdToModels, writerQueue))
+            calcProc = [mp.Process(target=self._processBin, args=(outDir, tableOut, hmmerOut, markerFile, bKeepAlignment, bNucORFs, bCalledGenes, workerQueue, writerQueue)) for _ in range(self.totalThreads)]
+            writeProc = mp.Process(target=self._reportProgress, args=(len(binFiles), binIdToModels, writerQueue))
 
             writeProc.start()
 
@@ -94,7 +94,7 @@ class MarkerGeneFinder():
 
         return d
 
-    def __processBin(self, outDir, tableOut, hmmerOut, markerFile, bKeepAlignment, bNucORFs, bCalledGenes, queueIn, queueOut):
+    def _processBin(self, outDir, tableOut, hmmerOut, markerFile, bKeepAlignment, bNucORFs, bCalledGenes, queueIn, queueOut):
         """Thread safe bin processing."""
 
         markerSetParser = MarkerSetParser(self.threadsPerSearch)
@@ -135,7 +135,7 @@ class MarkerGeneFinder():
 
             queueOut.put((binId, hmmModelFile))
 
-    def __reportProgress(self, numBins, binIdToModels, queueIn):
+    def _reportProgress(self, numBins, binIdToModels, queueIn):
         """Report number of processed bins."""
 
         numProcessedBins = 0

--- a/checkm/markerSets.py
+++ b/checkm/markerSets.py
@@ -333,10 +333,10 @@ class MarkerSetParser():
         hmmModelFile = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))
         if markerFileType == BinMarkerSets.TAXONOMIC_MARKER_SET:
             binMarkerSets = self.parseTaxonomicMarkerSetFile(markerFile)
-            self.__createMarkerHMMs(binMarkerSets, hmmModelFile, bReportProgress=False)
+            self._createMarkerHMMs(binMarkerSets, hmmModelFile, bReportProgress=False)
         elif markerFileType == BinMarkerSets.TREE_MARKER_SET:
             binIdToBinMarkerSets = self.parseLineageMarkerSetFile(markerFile)
-            self.__createMarkerHMMs(binIdToBinMarkerSets[binId], hmmModelFile, bReportProgress=False)
+            self._createMarkerHMMs(binIdToBinMarkerSets[binId], hmmModelFile, bReportProgress=False)
         else:
             shutil.copyfile(markerFile, hmmModelFile)
 
@@ -359,8 +359,8 @@ class MarkerSetParser():
         binIdToModels = mp.Manager().dict()
 
         try:
-            calcProc = [mp.Process(target=self.__fetchModelInfo, args=(binIdToModels, markerFile, workerQueue, writerQueue)) for _ in range(self.numThreads)]
-            writeProc = mp.Process(target=self.__reportFetchProgress, args=(len(binIds), writerQueue))
+            calcProc = [mp.Process(target=self._fetchModelInfo, args=(binIdToModels, markerFile, workerQueue, writerQueue)) for _ in range(self.numThreads)]
+            writeProc = mp.Process(target=self._reportFetchProgress, args=(len(binIds), writerQueue))
 
             writeProc.start()
 
@@ -386,7 +386,7 @@ class MarkerSetParser():
 
         return d
 
-    def __fetchModelInfo(self, binIdToModels, markerFile, queueIn, queueOut):
+    def _fetchModelInfo(self, binIdToModels, markerFile, queueIn, queueOut):
         """Fetch HMM."""
         while True:
             binId = queueIn.get(block=True, timeout=None)
@@ -402,7 +402,7 @@ class MarkerSetParser():
 
             queueOut.put(binId)
 
-    def __reportFetchProgress(self, numBins, queueIn):
+    def _reportFetchProgress(self, numBins, queueIn):
         """Report progress of extracted HMMs."""
 
         numProcessedBins = 0
@@ -440,7 +440,7 @@ class MarkerSetParser():
             self.logger.error('Unrecognized file type: ' + markerFile)
             sys.exit(1)
 
-    def __createMarkerHMMs(self, binMarkerSet, outputFile, bReportProgress=True):
+    def _createMarkerHMMs(self, binMarkerSet, outputFile, bReportProgress=True):
         """Create HMM file for markers."""
 
         # get list of marker genes

--- a/checkm/pplacer.py
+++ b/checkm/pplacer.py
@@ -40,8 +40,8 @@ class PplacerRunner():
         self.numThreads = threads
 
         # make sure pplace and guppy are on the system path
-        self.__checkForPplacer()
-        self.__checkForGuppy()
+        self._checkForPplacer()
+        self._checkForGuppy()
 
     def run(self, binFiles, resultsParser, outDir, bReducedTree):
         # make sure output and tree directories exist
@@ -54,7 +54,7 @@ class PplacerRunner():
         pplacerOut = os.path.join(alignOutputDir, DefaultValues.PPLACER_OUT)
 
         # create concatenated alignment file for each bin
-        concatenatedAlignFile = self.__createConcatenatedAlignment(binFiles, resultsParser, alignOutputDir)
+        concatenatedAlignFile = self._createConcatenatedAlignment(binFiles, resultsParser, alignOutputDir)
 
         pplacerRefPkg = DefaultValues.PPLACER_REF_PACKAGE_FULL
         if bReducedTree:
@@ -80,7 +80,7 @@ class PplacerRunner():
         cmd = 'guppy tog -o %s %s' % (treeFile, pplacerJsonOut)
         os.system(cmd)
 
-    def __createConcatenatedAlignment(self, binFiles, resultsParser, alignOutputDir):
+    def _createConcatenatedAlignment(self, binFiles, resultsParser, alignOutputDir):
         """Create a concatenated alignment of marker genes for each bin."""
 
         # read alignment files
@@ -125,7 +125,7 @@ class PplacerRunner():
 
         return concatenatedAlignFile
 
-    def __checkForPplacer(self):
+    def _checkForPplacer(self):
         """Check to see if pplacer is on the system before we try to run it."""
 
         # Assume that a successful pplacer -h returns 0 and anything
@@ -136,7 +136,7 @@ class PplacerRunner():
             self.logger.error("Make sure pplacer is on your system path.")
             sys.exit(1)
 
-    def __checkForGuppy(self):
+    def _checkForGuppy(self):
         """Check to see if guppy is on the system before we try to run it."""
 
         # Assume that a successful pplacer -h returns 0 and anything

--- a/checkm/prodigal.py
+++ b/checkm/prodigal.py
@@ -98,7 +98,7 @@ class ProdigalRunner():
 
             os.system(cmd)
 
-            if not self.__areORFsCalled(aaGeneFile) and procedureStr == 'single':
+            if not self._areORFsCalled(aaGeneFile) and procedureStr == 'single':
                 # prodigal will fail to learn a model if the input genome has a large number of N's
                 # so try gene prediction with 'meta'
                 cmd = cmd.replace('-p single', '-p meta')
@@ -142,7 +142,7 @@ class ProdigalRunner():
 
         return bestTranslationTable
 
-    def __areORFsCalled(self, aaGeneFile):
+    def _areORFsCalled(self, aaGeneFile):
         return os.path.exists(aaGeneFile) and os.stat(aaGeneFile)[stat.ST_SIZE] != 0
 
     def areORFsCalled(self, bNucORFs):
@@ -198,13 +198,13 @@ class ProdigalGeneFeatureParser():
         self.genes = {}
         self.lastCodingBase = {}
 
-        self.__parseGFF(filename)
+        self._parseGFF(filename)
 
         self.codingBaseMasks = {}
         for seqId in self.genes:
-            self.codingBaseMasks[seqId] = self.__buildCodingBaseMask(seqId)
+            self.codingBaseMasks[seqId] = self._buildCodingBaseMask(seqId)
 
-    def __parseGFF(self, filename):
+    def _parseGFF(self, filename):
         """Parse genes from GFF file."""
         self.translationTable = None
         for line in open(filename):
@@ -237,7 +237,7 @@ class ProdigalGeneFeatureParser():
             self.genes[seqId][geneId] = [start, end]
             self.lastCodingBase[seqId] = max(self.lastCodingBase[seqId], end)
 
-    def __buildCodingBaseMask(self, seqId):
+    def _buildCodingBaseMask(self, seqId):
         """Build mask indicating which bases in a sequences are coding."""
 
         # safe way to calculate coding bases as it accounts

--- a/checkm/resultsParser.py
+++ b/checkm/resultsParser.py
@@ -68,8 +68,8 @@ class ResultsParser():
 
     def cacheResults(self, outDir, binIdToBinMarkerSets, bIndividualMarkers):
         # cache critical results to file
-        self.__writeBinStatsExt(outDir, binIdToBinMarkerSets, bIndividualMarkers)
-        self.__writeMarkerGeneStats(outDir, binIdToBinMarkerSets, bIndividualMarkers)
+        self._writeBinStatsExt(outDir, binIdToBinMarkerSets, bIndividualMarkers)
+        self._writeMarkerGeneStats(outDir, binIdToBinMarkerSets, bIndividualMarkers)
 
     def parseBinHits(self, outDir,
                      hmmTableFile,
@@ -110,7 +110,7 @@ class ResultsParser():
         if self.logger.getEffectiveLevel() <= logging.INFO:
             sys.stderr.write('\n')
 
-    def __writeBinStatsExt(self, directory, binIdToBinMarkerSets, bIndividualMarkers):
+    def _writeBinStatsExt(self, directory, binIdToBinMarkerSets, bIndividualMarkers):
         binStatsExtFile = os.path.join(directory, 'storage', DefaultValues.BIN_STATS_EXT_OUT)
         fout = open(binStatsExtFile, 'w')
 
@@ -120,7 +120,7 @@ class ResultsParser():
             fout.write(binId + '\t' + str(binStatsExt) + '\n')
         fout.close()
 
-    def __writeMarkerGeneStats(self, directory, binIdToBinMarkerSets, bIndividualMarkers):
+    def _writeMarkerGeneStats(self, directory, binIdToBinMarkerSets, bIndividualMarkers):
         markerGenesFile = os.path.join(directory, 'storage', DefaultValues.MARKER_GENE_STATS)
         fout = open(markerGenesFile, 'w')
 
@@ -198,7 +198,7 @@ class ResultsParser():
         except IOError as detail:
             sys.stderr.write(str(detail) + "\n")
 
-    def __getHeader(self, outputFormat, binMarkerSets, coverageBinProfiles=None, table=None):
+    def _getHeader(self, outputFormat, binMarkerSets, coverageBinProfiles=None, table=None):
         """Get header for requested output table."""
 
         # keep count of single, double, triple genes etc...
@@ -255,7 +255,7 @@ class ResultsParser():
 
         prettyTableFormats = [1, 2, 3, 9]
 
-        header = self.__getHeader(outputFormat, binIdToBinMarkerSets[list(binIdToBinMarkerSets.keys())[0]], coverageBinProfiles, bTabTable)
+        header = self._getHeader(outputFormat, binIdToBinMarkerSets[list(binIdToBinMarkerSets.keys())[0]], coverageBinProfiles, bTabTable)
         if bTabTable or outputFormat not in prettyTableFormats:
             bTabTable = True
             pTable = None

--- a/checkm/ssuFinder.py
+++ b/checkm/ssuFinder.py
@@ -38,7 +38,7 @@ class SSU_Finder(object):
         self.archaeaModelFile = os.path.join(DefaultValues.CHECKM_DATA_DIR, 'hmms_ssu', 'SSU_archaea.hmm')
         self.eukModelFile = os.path.join(DefaultValues.CHECKM_DATA_DIR, 'hmms_ssu', 'SSU_euk.hmm')
 
-    def __hmmSearch(self, seqFile, evalue, outputPrefix):
+    def _hmmSearch(self, seqFile, evalue, outputPrefix):
         if seqFile.endswith('gz'):
             pipe = 'zcat ' + seqFile + ' | '
         else:
@@ -53,7 +53,7 @@ class SSU_Finder(object):
         self.logger.info('Identifying eukaryotic 18S.')
         os.system(pipe + 'nhmmer --noali --cpu ' + str(self.totalThreads) + ' -o ' + outputPrefix + '.euk.txt --tblout ' + outputPrefix + '.euk.table.txt -E ' + str(evalue) + ' ' + self.eukModelFile + ' -')
 
-    def __readHits(self, resultsFile, domain, evalueThreshold):
+    def _readHits(self, resultsFile, domain, evalueThreshold):
         """Parse hits from nhmmer output."""
         seqInfo = {}
 
@@ -88,7 +88,7 @@ class SSU_Finder(object):
 
         return seqInfo
 
-    def __addHit(self, hits, seqId, info, concatenateThreshold):
+    def _addHit(self, hits, seqId, info, concatenateThreshold):
         """Add hits from individual HMMs and concatenate nearby hits."""
 
         # check if this is the first hit to this sequence
@@ -147,7 +147,7 @@ class SSU_Finder(object):
                     hits[newSeqId] = info
                     break
 
-    def __addDomainHit(self, hits, baseSeqId, info):
+    def _addDomainHit(self, hits, baseSeqId, info):
         """Add hits from different domain models and concatenate nearby hits."""
         
         startNew = int(info[2])
@@ -203,18 +203,18 @@ class SSU_Finder(object):
 
         # identify 16S reads from contigs/scaffolds
         self.logger.info('Identifying SSU rRNAs on sequences.')
-        self.__hmmSearch(contigFile, evalueThreshold, os.path.join(outputDir, 'ssu'))
+        self._hmmSearch(contigFile, evalueThreshold, os.path.join(outputDir, 'ssu'))
 
         # read HMM hits
         hitsPerDomain = {}
         for domain in ['archaea', 'bacteria', 'euk']:
             hits = {}
 
-            seqInfo = self.__readHits(os.path.join(outputDir, 'ssu' + '.' + domain + '.txt'), domain, evalueThreshold)
+            seqInfo = self._readHits(os.path.join(outputDir, 'ssu' + '.' + domain + '.txt'), domain, evalueThreshold)
             if len(seqInfo) > 0:
                 for seqId, seqHits in seqInfo.items():
                     for hit in seqHits:
-                        self.__addHit(hits, seqId, hit, concatenateThreshold)
+                        self._addHit(hits, seqId, hit, concatenateThreshold)
 
             hitsPerDomain[domain] = hits
 
@@ -225,7 +225,7 @@ class SSU_Finder(object):
                 if '-#' in seqId:
                     seqId = seqId[0:seqId.rfind('-#')]
 
-                self.__addDomainHit(bestHits, seqId, info)
+                self._addDomainHit(bestHits, seqId, info)
                 
         # relabel hits
         newBestHits = {}

--- a/checkm/treeParser.py
+++ b/checkm/treeParser.py
@@ -63,7 +63,7 @@ class TreeParser():
             print(line.rstrip())
 
         # read duplicate seqs
-        duplicateNodes = self.__readDuplicateSeqs()
+        duplicateNodes = self._readDuplicateSeqs()
 
         # write reference alignments to file
         seqs = readFasta(os.path.join(DefaultValues.PPLACER_REF_PACKAGE_FULL, DefaultValues.GENOME_TREE_FASTA))
@@ -100,7 +100,7 @@ class TreeParser():
 
     def reportNewickTree(self, outDir, outFile, leafLabels=None):
         # read duplicate nodes
-        duplicateSeqs = self.__readDuplicateSeqs()
+        duplicateSeqs = self._readDuplicateSeqs()
 
         # read tree
         treeFile = os.path.join(outDir, 'storage', 'tree', DefaultValues.PPLACER_TREE_OUT)
@@ -213,14 +213,14 @@ class TreeParser():
                 parentNode = parentNode.parent_node
 
             if not taxaStr:
-                domainNode = self.__findDomainNode(node)
+                domainNode = self._findDomainNode(node)
                 taxaStr = domainNode.label.split('|')[1] + ' (root)'
 
             binIdToTaxonomy[node.taxon.label] = taxaStr
 
         return binIdToTaxonomy
 
-    def __findDomainNode(self, binNode):
+    def _findDomainNode(self, binNode):
         """Find node defining the domain. Assumes 'binNode' is the leaf node of a bin on either the archaeal or bacterial branch."""
 
         # bin is either on the bacterial or archaeal branch descendant from the root,
@@ -324,7 +324,7 @@ class TreeParser():
 
         return binIdToSisterTaxonomy
 
-    def __getNextNamedNode(self, node, uniqueIdToLineageStatistics):
+    def _getNextNamedNode(self, node, uniqueIdToLineageStatistics):
         """Get first parent node with taxonomy information."""
         parentNode = node.parent_node
         while True:
@@ -341,9 +341,9 @@ class TreeParser():
 
         return 'root'
 
-    def __getMarkerSet(self, parentNode, tree, uniqueIdToLineageStatistics,
-                                    numGenomesMarkers, bootstrap,
-                                    bForceDomain, bRequireTaxonomy):
+    def _getMarkerSet(self, parentNode, tree, uniqueIdToLineageStatistics,
+                      numGenomesMarkers, bootstrap,
+                      bForceDomain, bRequireTaxonomy):
         """Get marker set for next parent node meeting selection criteria."""
 
         # ascend tree to root finding first node meeting all selection criteria
@@ -363,7 +363,7 @@ class TreeParser():
                             # get closest taxonomic label
                             taxonomyStr = stats['taxonomy']
                             if not bRequireTaxonomy and stats['taxonomy'] == '':
-                                taxonomyStr = self.__getNextNamedNode(selectedParentNode, uniqueIdToLineageStatistics)
+                                taxonomyStr = self._getNextNamedNode(selectedParentNode, uniqueIdToLineageStatistics)
 
                             # all criteria meet, so use marker set from this node
                             break
@@ -379,7 +379,7 @@ class TreeParser():
 
         return selectedParentNode, markerSet
 
-    def __refineMarkerSet(self, markerSet, binNode, tree, uniqueIdToLineageStatistics, numGenomesRefine):
+    def _refineMarkerSet(self, markerSet, binNode, tree, uniqueIdToLineageStatistics, numGenomesRefine):
         """Refine marker set to account for lineage-specific gene loss and duplication."""
 
         # lineage-specific refine is done with the sister lineage to where the bin is inserted
@@ -427,7 +427,7 @@ class TreeParser():
 
         return refinedMarkerSet
 
-    def __readLineageSpecificGenesToRemove(self):
+    def _readLineageSpecificGenesToRemove(self):
         """Get set of genes subject to lineage-specific gene loss and duplication."""
 
         self.lineageSpecificGenesToRemove = {}
@@ -438,7 +438,7 @@ class TreeParser():
             duplicateGenes = eval(lineSplit[2])
             self.lineageSpecificGenesToRemove[uid] = missingGenes.union(duplicateGenes)
 
-    def __removeInvalidLineageMarkerGenes(self, markerSet, lineageSpecificMarkersToRemove):
+    def _removeInvalidLineageMarkerGenes(self, markerSet, lineageSpecificMarkersToRemove):
         """Refine marker set to account for lineage-specific gene loss and duplication."""
 
         # refine marker set by removing marker genes subject to lineage-specific
@@ -502,9 +502,9 @@ class TreeParser():
             binMarkerSets = BinMarkerSets(binId, BinMarkerSets.TREE_MARKER_SET)
             if node == None:
                 # bin is not in tree
-                node, markerSet = self.__getMarkerSet(rootNode, tree, uniqueIdToLineageStatistics,
-                                                        numGenomesMarkers, bootstrap,
-                                                        bForceDomain, bRequireTaxonomy)
+                node, markerSet = self._getMarkerSet(rootNode, tree, uniqueIdToLineageStatistics,
+                                                     numGenomesMarkers, bootstrap,
+                                                     bForceDomain, bRequireTaxonomy)
                 binMarkerSets.addMarkerSet(markerSet)
             else:
                 # special case: if node is on the bacterial or archaeal branch descendant from the root,
@@ -520,7 +520,7 @@ class TreeParser():
                 if bRoot:
                     # since the root is the first labeled node, we need to descend the
                     # tree to incorporate the domain-specific marker set
-                    domainNode = self.__findDomainNode(node)
+                    domainNode = self._findDomainNode(node)
                     curNode = domainNode.child_nodes()[0]
                 else:
                     curNode = node
@@ -528,7 +528,7 @@ class TreeParser():
                 # get lineage specific refinement for first node with an id
                 if not bNoLineageSpecificRefinement:
                     uniqueId = parentNode.label.split('|')[0]
-                    self.__readLineageSpecificGenesToRemove()
+                    self._readLineageSpecificGenesToRemove()
                     lineageSpecificRefinement = self.lineageSpecificGenesToRemove[uniqueId]
 
                 # ascend tree to root, recording all marker sets meeting selection criteria
@@ -536,12 +536,12 @@ class TreeParser():
                     uniqueHits, multiCopyHits = resultsParser.results[binId].countUniqueHits()
                     tempForceDomain = bForceDomain or (uniqueHits < minUnique) or (multiCopyHits > maxMulti)
 
-                    curNode, markerSet = self.__getMarkerSet(curNode.parent_node, tree, uniqueIdToLineageStatistics,
-                                                                numGenomesMarkers, bootstrap,
-                                                                tempForceDomain, bRequireTaxonomy)
+                    curNode, markerSet = self._getMarkerSet(curNode.parent_node, tree, uniqueIdToLineageStatistics,
+                                                            numGenomesMarkers, bootstrap,
+                                                            tempForceDomain, bRequireTaxonomy)
 
                     if not bNoLineageSpecificRefinement:
-                        markerSet = self.__removeInvalidLineageMarkerGenes(markerSet, lineageSpecificRefinement)
+                        markerSet = self._removeInvalidLineageMarkerGenes(markerSet, lineageSpecificRefinement)
 
                     binMarkerSets.addMarkerSet(markerSet)
 
@@ -642,16 +642,16 @@ class TreeParser():
 
         # write table
         if not bLineageStatistics:
-            self.__printSimpleSummaryTable(binIdToTaxonomy, resultsParser, bTabTable, outFile)
+            self._printSimpleSummaryTable(binIdToTaxonomy, resultsParser, bTabTable, outFile)
         else:
             # get taxonomy of sister lineage for each bin
             binIdToSisterTaxonomy = self.getBinSisterTaxonomy(outDir, binIds)
             binIdToUID = self.getInsertionBranchId(outDir, binIds)
 
             binIdToLineageStatistics = self.readLineageMetadata(outDir, binIds)
-            self.__printFullTable(binIdToUID, binIdToTaxonomy, binIdToSisterTaxonomy, binIdToLineageStatistics, resultsParser, binStats, bTabTable, outFile)
+            self._printFullTable(binIdToUID, binIdToTaxonomy, binIdToSisterTaxonomy, binIdToLineageStatistics, resultsParser, binStats, bTabTable, outFile)
 
-    def __printSimpleSummaryTable(self, binIdToTaxonomy, resultsParser, bTabTable, outFile):
+    def _printSimpleSummaryTable(self, binIdToTaxonomy, resultsParser, bTabTable, outFile):
         # redirect output
         oldStdOut = reassignStdOut(outFile)
 
@@ -687,7 +687,7 @@ class TreeParser():
         # restore stdout
         restoreStdOut(outFile, oldStdOut)
 
-    def __printFullTable(self, binIdToUID, binIdToTaxonomy, binIdToSisterTaxonomy, binIdToLineageStatistics, resultsParser, binStats, bTabTable, outFile):
+    def _printFullTable(self, binIdToUID, binIdToTaxonomy, binIdToSisterTaxonomy, binIdToLineageStatistics, resultsParser, binStats, bTabTable, outFile):
         # redirect output
         oldStdOut = reassignStdOut(outFile)
 
@@ -757,7 +757,7 @@ class TreeParser():
         # restore stdout
         restoreStdOut(outFile, oldStdOut)
 
-    def __readDuplicateSeqs(self):
+    def _readDuplicateSeqs(self):
         """Parse file indicating duplicate sequence alignments."""
         duplicateSeqs = {}
         for line in open(os.path.join(DefaultValues.GENOME_TREE_DIR, DefaultValues.GENOME_TREE_DEREP)):

--- a/checkm/util/img.py
+++ b/checkm/util/img.py
@@ -308,7 +308,7 @@ class IMG(object):
 
         return table
 
-    def __genomeIdToClusterScaffold(self, genomeId):
+    def _genomeIdToClusterScaffold(self, genomeId):
         """Determine position of PFAM and TIGRFAM genes in genome."""
 
         # determine mapping from gene ids to PFAM/TIGRFAM ids
@@ -362,7 +362,7 @@ class IMG(object):
                 if scaffold:
                     familyIdToScaffoldIds[tigrId] = scaffolds
         except:
-            print ('[BUG]: __genomeIdToClusterScaffold')
+            print ('[BUG]: _genomeIdToClusterScaffold')
             print (sys.exc_info()[0])
             print (genomeId, geneId, tigrId, pfamId)
             sys.exit(1)
@@ -376,7 +376,7 @@ class IMG(object):
         # that are called multiple times (typically during simulations)
         self.cachedGenomeFamilyScaffolds = {}
         for genomeId in genomeIds:
-            self.cachedGenomeFamilyScaffolds[genomeId] = self.__genomeIdToClusterScaffold(genomeId)
+            self.cachedGenomeFamilyScaffolds[genomeId] = self._genomeIdToClusterScaffold(genomeId)
 
         return self.cachedGenomeFamilyScaffolds
 
@@ -394,7 +394,7 @@ class IMG(object):
 
         return familyIdToGeneId
 
-    def __genomeSeqLens(self, genomeId):
+    def _genomeSeqLens(self, genomeId):
         """Determine length of contigs/scaffolds comprising genome."""
         genomeFile = os.path.join(self.genomeDir, genomeId, genomeId + '.fna')
         seqs = readFasta(genomeFile)
@@ -413,11 +413,11 @@ class IMG(object):
 
         self.cachedGenomeSeqLens = {}
         for genomeId in genomeIds:
-            self.cachedGenomeSeqLens[genomeId] = self.__genomeSeqLens(genomeId)
+            self.cachedGenomeSeqLens[genomeId] = self._genomeSeqLens(genomeId)
 
         return self.cachedGenomeSeqLens
 
-    def __genomeFamilyPositions(self, genomeId, seqLens, spacingBetweenContigs):
+    def _genomeFamilyPositions(self, genomeId, seqLens, spacingBetweenContigs):
         """Determine position of PFAM and TIGRFAM genes in genome."""
 
         # determine mapping from gene ids to PFAM/TIGRFAM ids
@@ -482,7 +482,7 @@ class IMG(object):
                 if positions:
                     familyIdToGenomePositions[tigrId] = positions
         except:
-            print ('[BUG]: __genomeFamilyPositions')
+            print ('[BUG]: _genomeFamilyPositions')
             print (sys.exc_info()[0])
             print (genomeId, geneId, tigrId, pfamId)
             sys.exit(1)
@@ -496,7 +496,7 @@ class IMG(object):
         # that are called multiple times (typically during simulations)
         self.cachedGenomeFamilyPositions = {}
         for genomeId in genomeIds:
-            self.cachedGenomeFamilyPositions[genomeId] = self.__genomeFamilyPositions(genomeId, self.cachedGenomeSeqLens[genomeId], spacingBetweenContigs)
+            self.cachedGenomeFamilyPositions[genomeId] = self._genomeFamilyPositions(genomeId, self.cachedGenomeSeqLens[genomeId], spacingBetweenContigs)
 
     def geneDistTable(self, genomeIds, markerGenes, spacingBetweenContigs=0):
         """Create table indicating position of each marker gene in a genome."""
@@ -510,13 +510,13 @@ class IMG(object):
             if self.cachedGenomeSeqLens:
                 seqLens = self.cachedGenomeSeqLens[genomeId]
             else:
-                seqLens = self.__genomeSeqLens(genomeId)
+                seqLens = self._genomeSeqLens(genomeId)
 
             # read position of protein families on genome
             if self.cachedGenomeFamilyPositions:
                 genomeFamilyPositions = self.cachedGenomeFamilyPositions[genomeId]
             else:
-                genomeFamilyPositions = self.__genomeFamilyPositions(genomeId, seqLens, spacingBetweenContigs)
+                genomeFamilyPositions = self._genomeFamilyPositions(genomeId, seqLens, spacingBetweenContigs)
 
             # create marker gene position table for genome
             clusterIdToGenomePositions = {}

--- a/checkm/util/taxonomyUtils.py
+++ b/checkm/util/taxonomyUtils.py
@@ -57,7 +57,7 @@ def readTaxonomy(taxonomyFile):
     return taxonIdToTaxonomy
 
 
-def __parseTaxon(taxon):
+def _parseTaxon(taxon):
     if '(' in taxon:
         taxonSplit = taxon.split('(')
         taxonId = taxonSplit[0]
@@ -74,8 +74,8 @@ def LCA(taxonomy1, taxonomy2):
     """Find lowest-common ancestor between two taxa lists."""
     lca = []
     for i in range(0, min(len(taxonomy1), len(taxonomy2))):
-        t1, b1 = __parseTaxon(taxonomy1[i])
-        t2, b2 = __parseTaxon(taxonomy2[i])
+        t1, b1 = _parseTaxon(taxonomy1[i])
+        t2, b2 = _parseTaxon(taxonomy2[i])
 
         if t1 != t2:
             if 'unmapped' in t1 or 'unmapped' in t2:


### PR DESCRIPTION
I have stumbled upon the bug described in issues #272 and #280 when using the most recent version of CheckM on macOS. It seemed to be limited to python 3.8 (while all worked as expected on 3.6 and 3.7) - a small poking around brought me to this issue: https://github.com/python/cpython/issues/88841. In short, it seems there is a bug when using multiprocessing in combination with private `__methods` that was introduced in cpython somewhere around python 3.8 which leads to the `AttributeError`s described in those linked issues.

It is not clear to me whether this is going to be fixed or not on the python level and since CheckM is basically (mostly) unusable on python >=3.8 I renamed all of the private methods to only use a single underscore (_all_ of them, even if they are not used in combination with multiprocessing, for consistency). I hope that's ok - of course, feedback will be very much appreciated :) 